### PR TITLE
asRemotable has been deleted

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,10 +15,10 @@
 
   <properties>
     <jclouds.version>2.0.3</jclouds.version>
-    <jenkins-core.version>2.114-20180326.224001-1</jenkins-core.version> <!-- TODO https://github.com/jenkinsci/jenkins/pull/3302 -->
-    <jenkins-war.version>2.114-20180326.224035-1</jenkins-war.version>
+    <jenkins-core.version>2.115-20180402.200252-1</jenkins-core.version> <!-- TODO https://github.com/jenkinsci/jenkins/pull/3302 -->
+    <jenkins-war.version>2.115-20180402.200314-1</jenkins-war.version>
     <java.level>8</java.level>
-    <workflow-api-plugin.version>2.27-20180326.224801-10</workflow-api-plugin.version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/67 -->
+    <workflow-api-plugin.version>2.27-20180402.200639-11</workflow-api-plugin.version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/67 -->
     <useBeta>true</useBeta>
   </properties>
 

--- a/src/main/java/io/jenkins/plugins/artifact_manager_s3/JCloudsBlobStore.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_s3/JCloudsBlobStore.java
@@ -109,12 +109,6 @@ class JCloudsBlobStore extends VirtualFile {
         return key;
     }
 
-    @Override
-    @NonNull
-    public VirtualFile asRemotable() {
-        return this;
-    }
-
     /**
      * Returns the base name
      */


### PR DESCRIPTION
As of https://github.com/jenkinsci/jenkins/pull/3302/commits/547fd6fe6ef2823d04a1517fb08f6d714ff4423a in https://github.com/jenkinsci/jenkins/pull/3302, plus matching commits in https://github.com/jenkinsci/workflow-api-plugin/pull/67, https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/60, and https://github.com/jenkinsci/copyartifact-plugin/pull/100, `VirtualFile.asRemotable` has been dropped in favor of `toExternalURL` everywhere.