### PR TITLE
[JENKINS-50668] Prevent loading file in memory on upload

### DIFF
--- a/src/main/java/io/jenkins/plugins/artifact_manager_s3/JCloudsArtifactManager.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_s3/JCloudsArtifactManager.java
@@ -349,6 +349,7 @@ class JCloudsArtifactManager extends ArtifactManager implements StashManager.Sta
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         connection.setDoOutput(true);
         connection.setRequestMethod("PUT");
+        connection.setFixedLengthStreamingMode(Files.size(f)); // prevent loading file in memory
         try (OutputStream out = connection.getOutputStream()) {
             Files.copy(f, out);
         }


### PR DESCRIPTION
Fixes java.lang.OutOfMemoryError: Java heap space