### PR TITLE
Only run build on Linux

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 if (infra.isRunningOnJenkinsInfra()) {
     // ci.jenkins.io
-    buildPlugin()
+    buildPlugin(platforms: ['linux'])
 } else if (env.CHANGE_FORK == null) { // TODO pending JENKINS-45970
     // to run tests on S3
     buildArtifactManagerPluginOnAWS()


### PR DESCRIPTION
Since all of the interesting tests are skipped in ci.jenkins.io anyway, there is no purpose to rerunning tests on Windows.