### PR TITLE
[JENKINS-51183] - Introduce Integration testing flow with BOM

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,9 @@
 if (infra.isRunningOnJenkinsInfra()) {
     // ci.jenkins.io
     buildPlugin(platforms: ['linux'])
+
+    // Integration tests
+    essentialsTest(baseDir: "src/test/it")
 } else if (env.CHANGE_FORK == null) { // TODO pending JENKINS-45970
     // to run tests on S3
     buildArtifactManagerPluginOnAWS()

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManagerFactory.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManagerFactory.java
@@ -44,7 +44,7 @@ public class JCloudsArtifactManagerFactory extends ArtifactManagerFactory {
     @DataBoundConstructor
     public JCloudsArtifactManagerFactory(BlobStoreProvider provider) {
         if (provider == null) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("Missing provider field");
         }
         this.provider = provider;
     }

--- a/src/test/it/Makefile
+++ b/src/test/it/Makefile
@@ -1,0 +1,37 @@
+# Just a Makefile for manual testing
+.PHONY: all
+
+ARTIFACT_ID = jenkins-war
+VERSION = 2.121-artifact-manager-s3-SNAPSHOT
+CWP_VERSION = 0.1-alpha-6-20180524.212000-3
+
+all: clean build
+
+clean:
+	rm -rf tmp
+
+build: tmp/output/target/${ARTIFACT_ID}-${VERSION}.war
+
+tmp/output/target/${ARTIFACT_ID}-${VERSION}.war:
+	mvn io.jenkins.tools.custom-war-packager:custom-war-packager-maven-plugin:${CWP_VERSION}:build \
+	    --errors \
+	    -Denvironment=aws \
+	    -DconfigFile=essentials.yml -Dversion=${VERSION} -DbomFile=bom.yml
+
+run: tmp/output/target/${ARTIFACT_ID}-${VERSION}.war
+	JENKINS_HOME=work java \
+	    -Dartifact-manager-s3.enabled=true \
+	    -jar tmp/output/target/${ARTIFACT_ID}-${VERSION}.war \
+        --httpPort=8080 --prefix=/jenkins
+
+pct: tmp/output/target/${ARTIFACT_ID}-${VERSION}.war
+	docker run --rm \
+	    -v ${HOME}/.m2:/root/.m2 \
+	    -v $(shell pwd)/pct_out:/pct/out \
+	    -v $(shell pwd)/pct_tmp:/pct/tmp \
+		-v $(shell pwd)/tmp/output/target/${ARTIFACT_ID}-${VERSION}.war:/pct/jenkins.war:ro \
+		-e ARTIFACT_ID=artifact-manager-s3 \
+		-e INSTALL_BUNDLED_SNAPSHOTS=true \
+		jenkins/pct \
+		-mavenProperties jenkins-test-harness.version=2.38:jth.jenkins-war.path=/pct/jenkins.war
+

--- a/src/test/it/Makefile
+++ b/src/test/it/Makefile
@@ -3,7 +3,7 @@
 
 ARTIFACT_ID = jenkins-war
 VERSION = 2.121-artifact-manager-s3-SNAPSHOT
-CWP_VERSION = 0.1-alpha-6-20180524.212000-3
+CWP_VERSION = 0.1-alpha-6
 
 all: clean build
 

--- a/src/test/it/bom.yml
+++ b/src/test/it/bom.yml
@@ -1,0 +1,56 @@
+metadata:
+  # labels and annotations are key: value string attributes
+  labels:
+    name: bom-it
+    # Needed to make PCT happy
+    groupId: org.jenkins-ci.main
+    artifactId: jenkins-war
+    version: 2.118-artifact-manager-s3-SNAPSHOT
+spec:
+  core:
+    version: 2.118
+  plugins:
+    - groupId: "org.jenkins-ci.plugins.workflow"
+      artifactId: "workflow-api"
+      version:  2.28-rc333.0675e9e9cb4c
+    - groupId: "org.jenkins-ci.plugins"
+      artifactId: "copyartifact"
+      version: 1.40-rc298.60da56cfabea
+    # Maven HPI Plugin improperly resolves dependency trees, needs upper bounds check
+    - groupId: "org.jenkins-ci.plugins"
+      artifactId: "structs"
+      version: 1.14
+    - groupId: "org.jenkins-ci.plugins.workflow"
+      artifactId: "workflow-step-api"
+      version: 2.14
+    - groupId: "org.jenkins-ci.plugins.workflow"
+      artifactId: "workflow-job"
+      version: 2.20
+    - groupId: "org.jenkins-ci.plugins.workflow"
+      artifactId: "workflow-basic-steps"
+      version: 2.7
+    - groupId: "org.jenkins-ci.plugins.workflow"
+      artifactId: "workflow-support"
+      version: 2.18
+    - groupId: "org.jenkins-ci.plugins"
+      artifactId: "junit"
+      version: 1.24
+    - groupId: "org.jenkins-ci.plugins"
+      artifactId: "mailer"
+      version: 1.21
+    - groupId: "org.jenkins-ci.plugins"
+      artifactId: "scm-api"
+      version: 2.2.7
+    - groupId: "org.jenkins-ci.plugins"
+      artifactId: "script-security"
+      version: 1.44
+    - groupId: "org.jenkins-ci.plugins"
+      artifactId: "aws-java-sdk"
+      version: 1.11.264
+  environments:
+    - name: aws
+      plugins:
+        #TODO: BOM does not support FileSystem REFs, so somebody needs to add BOM auto-update logic here
+        - groupId: "io.jenkins.plugins"
+          artifactId: "artifact-manager-s3"
+          version: 1.0-alpha-1-rc20.60688a35a736

--- a/src/test/it/bom.yml
+++ b/src/test/it/bom.yml
@@ -50,7 +50,6 @@ spec:
   environments:
     - name: aws
       plugins:
-        #TODO: BOM does not support FileSystem REFs, so somebody needs to add BOM auto-update logic here
         - groupId: "io.jenkins.plugins"
           artifactId: "artifact-manager-s3"
-          version: 1.0-alpha-1-rc20.60688a35a736
+          dir: ../../..

--- a/src/test/it/bom.yml
+++ b/src/test/it/bom.yml
@@ -5,14 +5,14 @@ metadata:
     # Needed to make PCT happy
     groupId: org.jenkins-ci.main
     artifactId: jenkins-war
-    version: 2.118-artifact-manager-s3-SNAPSHOT
+    version: 2.121-artifact-manager-s3-SNAPSHOT
 spec:
   core:
-    version: 2.118
+    version: 2.121
   plugins:
     - groupId: "org.jenkins-ci.plugins.workflow"
       artifactId: "workflow-api"
-      version:  2.28-rc333.0675e9e9cb4c
+      version:  2.28-rc337.8abe7c5204d9
     - groupId: "org.jenkins-ci.plugins"
       artifactId: "copyartifact"
       version: 1.40-rc298.60da56cfabea
@@ -22,13 +22,13 @@ spec:
       version: 1.14
     - groupId: "org.jenkins-ci.plugins.workflow"
       artifactId: "workflow-step-api"
-      version: 2.14
+      version: 2.15-rc308.607bdefd8c6a
     - groupId: "org.jenkins-ci.plugins.workflow"
       artifactId: "workflow-job"
       version: 2.20
     - groupId: "org.jenkins-ci.plugins.workflow"
       artifactId: "workflow-basic-steps"
-      version: 2.7
+      version: 2.8-rc351.c6608322f479
     - groupId: "org.jenkins-ci.plugins.workflow"
       artifactId: "workflow-support"
       version: 2.18

--- a/src/test/it/essentials.yml
+++ b/src/test/it/essentials.yml
@@ -2,6 +2,7 @@
 packaging:
   bom: bom.yml
   environment: aws
+  archiveArtifacts: true
   config:
     bundle:
       vendor: "Jenkins project"
@@ -13,6 +14,8 @@ packaging:
         source:
           dir: initScripts
 ath:
+  # TODO: ATH test dependency issues
+  enabled: false
   useLocalSnapshots: false
   tests:
     - "core.ArtifactsTest"

--- a/src/test/it/essentials.yml
+++ b/src/test/it/essentials.yml
@@ -1,0 +1,35 @@
+---
+packaging:
+  bom: bom.yml
+  environment: aws
+  config:
+    bundle:
+      vendor: "Jenkins project"
+      title: "Jenkins WAR - Artifact Manager S3 Integration Tests"
+      description: "Demo build, which includes Artifact Manager S3 and plugins using ArtifactManager API for testing"
+    groovyHooks:
+      - type: "init"
+        id: "initScripts"
+        source:
+          dir: src/main/groovy
+ath:
+  disabled: true
+  useLocalSnapshots: false
+  tests:
+    - "core.ArtifactsTest"
+    - "plugins.CopyArtifactPluginTest"
+    - "plugins.CompressArtifactsPluginTest"
+    - "plugins.WorkflowPluginTest"
+    - "plugins.WorkflowMultibranchTest"
+  categories:
+    - "org.jenkinsci.test.acceptance.junit.SmokeTest"
+pct:
+  disabled: true
+  useLocalSnapshots: false
+  jth:
+    version: 2.38
+    passCustomJenkinsWAR: true
+  plugins:
+    - "copyartifact"
+    - "workflow-job"
+    - "workflow-basic-steps"

--- a/src/test/it/essentials.yml
+++ b/src/test/it/essentials.yml
@@ -11,7 +11,7 @@ packaging:
       - type: "init"
         id: "initScripts"
         source:
-          dir: src/main/groovy
+          dir: initScripts
 ath:
   disabled: true
   useLocalSnapshots: false

--- a/src/test/it/essentials.yml
+++ b/src/test/it/essentials.yml
@@ -13,7 +13,6 @@ packaging:
         source:
           dir: initScripts
 ath:
-  disabled: true
   useLocalSnapshots: false
   tests:
     - "core.ArtifactsTest"
@@ -24,7 +23,6 @@ ath:
   categories:
     - "org.jenkinsci.test.acceptance.junit.SmokeTest"
 pct:
-  disabled: true
   useLocalSnapshots: false
   jth:
     version: 2.38

--- a/src/test/it/essentials.yml
+++ b/src/test/it/essentials.yml
@@ -3,6 +3,7 @@ packaging:
   bom: bom.yml
   environment: aws
   archiveArtifacts: true
+  cwpVersion: 0.1-alpha-6-20180524.212000-3
   config:
     bundle:
       vendor: "Jenkins project"

--- a/src/test/it/essentials.yml
+++ b/src/test/it/essentials.yml
@@ -3,7 +3,7 @@ packaging:
   bom: bom.yml
   environment: aws
   archiveArtifacts: true
-  cwpVersion: 0.1-alpha-6-20180524.212000-3
+  cwpVersion: 0.1-alpha-6
   config:
     bundle:
       vendor: "Jenkins project"

--- a/src/test/it/essentials.yml
+++ b/src/test/it/essentials.yml
@@ -15,7 +15,7 @@ packaging:
           dir: initScripts
 ath:
   # TODO: ATH test dependency issues
-  enabled: false
+  disabled: true
   useLocalSnapshots: false
   tests:
     - "core.ArtifactsTest"

--- a/src/test/it/initScripts/enableArtifactManager.groovy
+++ b/src/test/it/initScripts/enableArtifactManager.groovy
@@ -1,0 +1,13 @@
+import jenkins.model.ArtifactManagerConfiguration
+import io.jenkins.plugins.artifact_manager_s3.JCloudsArtifactManager
+import io.jenkins.plugins.artifact_manager_s3.JCloudsArtifactManagerFactory
+
+// Predefine storage and prefix when run in test on AWS
+if (Boolean.getBoolean("artifact-manager-s3.enabled")) {
+    println("--- Enabling default artifact storage: ${factory.descriptor.displayName}")
+
+    def factory = new JCloudsArtifactManagerFactory();
+    ArtifactManagerConfiguration.get().artifactManagerFactories.add(factory)
+    JCloudsArtifactManager.@BLOB_CONTAINER = "artifact-manager-s3"
+    JCloudsArtifactManager.@PREFIX = "integration-tests/"
+}

--- a/src/test/it/initScripts/enableArtifactManager.groovy
+++ b/src/test/it/initScripts/enableArtifactManager.groovy
@@ -1,13 +1,13 @@
 import jenkins.model.ArtifactManagerConfiguration
-import io.jenkins.plugins.artifact_manager_s3.JCloudsArtifactManager
-import io.jenkins.plugins.artifact_manager_s3.JCloudsArtifactManagerFactory
+import io.jenkins.plugins.artifact_manager_jclouds.JCloudsArtifactManagerFactory
+import io.jenkins.plugins.artifact_manager_s3.S3BlobStore
 
 // Predefine storage and prefix when run in test on AWS
 if (Boolean.getBoolean("artifact-manager-s3.enabled")) {
+    def factory = new JCloudsArtifactManagerFactory(new S3BlobStore());
     println("--- Enabling default artifact storage: ${factory.descriptor.displayName}")
 
-    def factory = new JCloudsArtifactManagerFactory();
     ArtifactManagerConfiguration.get().artifactManagerFactories.add(factory)
-    JCloudsArtifactManager.@BLOB_CONTAINER = "artifact-manager-s3"
-    JCloudsArtifactManager.@PREFIX = "integration-tests/"
+    S3BlobStore.@BLOB_CONTAINER = "artifact-manager-s3"
+    S3BlobStore.@PREFIX = "integration-tests/"
 }


### PR DESCRIPTION
Reference implementation for https://github.com/jenkins-infra/pipeline-library/pull/57 . It does not do anything exactly useful outside AWS environment, and the `artifact-manager-s3.enabled` system property should be set for it. 

On Jenkins Infra (which is on Azure) it will just run some bits with an Existing Artifact manager and new APIs. So it will smoke-tests plugins for the case when an ArtifactManager is present but not enabled. Maybe useful, but not that much.

But it is a good testing playground for @jglick's Incrementals auto-update logic (see TODO in BOM)

https://issues.jenkins-ci.org/browse/JENKINS-51183

@reviewbybees @jglick @carlossg 
