### PR TITLE
[JENKINS-50597] Network behavior tuning II

### DIFF
--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/NetworkTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/NetworkTest.java
@@ -71,10 +71,11 @@ public class NetworkTest {
     public void unrecoverableExceptionArchiving() throws Exception {
         WorkflowJob p = r.createProject(WorkflowJob.class, "p");
         r.createSlave("remote", null, null);
-        MockBlobStore.failIn(BlobStoreProvider.HttpMethod.PUT, "p/1/artifacts/f", 400);
+        MockBlobStore.failIn(BlobStoreProvider.HttpMethod.PUT, "p/1/artifacts/f", 403);
         p.setDefinition(new CpsFlowDefinition("node('remote') {writeFile file: 'f', text: '.'; archiveArtifacts 'f'}", true));
         WorkflowRun b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
-        r.assertLogContains("/container/p/1/artifacts/f?…, response: 400 simulated 400 failure, body: Detailed explanation of 400.", b);
+        r.assertLogContains("/container/p/1/artifacts/f?…, response: 403 simulated 403 failure, body: Detailed explanation of 403.", b);
+        r.assertLogNotContains("Retrying upload", b);
     }
 
     @Test
@@ -85,6 +86,7 @@ public class NetworkTest {
         p.setDefinition(new CpsFlowDefinition("node('remote') {writeFile file: 'f', text: '.'; archiveArtifacts 'f'}", true));
         WorkflowRun b = r.buildAndAssertSuccess(p);
         r.assertLogContains("/container/p/1/artifacts/f?…, response: 500 simulated 500 failure, body: Detailed explanation of 500.", b);
+        r.assertLogContains("Retrying upload", b);
     }
 
     @Test
@@ -95,6 +97,7 @@ public class NetworkTest {
         p.setDefinition(new CpsFlowDefinition("node('remote') {writeFile file: 'f', text: '.'; archiveArtifacts 'f'}", true));
         WorkflowRun b = r.buildAndAssertSuccess(p);
         // currently prints a ‘java.net.SocketException: Connection reset’ but not sure if we really care
+        r.assertLogContains("Retrying upload", b);
     }
 
 }


### PR DESCRIPTION
Continuing work from #34.

- [X] errors from file upload (`archiveArtifacts`, `stash`)
- [ ] endless errors from upload
- [ ] hangs from upload
- [ ] interruption during upload
- [ ] errors from file download (`unarchive`, `unstash`)
- [ ] hangs from download
- [ ] interruption during download
- [ ] errors/hangs/interruption during bucket list prior to `unarchive`
- [ ] errors/hangs/interruption during artifact/stash deletion/copy
- [ ] errors/hangs/interruption during master download (`*zip*` URLs)