### PR TITLE
[JENKINS-50597] Network behavior tuning III

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.11</version>
+    <version>3.12</version>
     <relativePath />
   </parent>
   <groupId>io.jenkins.plugins</groupId>
@@ -191,7 +191,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-step-api</artifactId>
-        <version>2.15</version>
+        <version>2.16-rc310.04f07c15faaf</version> <!-- TODO https://github.com/jenkinsci/workflow-step-api-plugin/pull/37 -->
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
@@ -393,7 +393,7 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
      * Upload a file to a URL
      */
     @SuppressWarnings("Convert2Lambda") // bogus use of generics (type variable should have been on class); cannot be made into a lambda
-    private static void uploadFile(Path f, URL url, final TaskListener listener, int stopAfterAttemptNumber, long waitMultiplier, long waitMaximum, long timeout) throws IOException {
+    private static void uploadFile(Path f, URL url, final TaskListener listener, int stopAfterAttemptNumber, long waitMultiplier, long waitMaximum, long timeout) throws IOException, InterruptedException {
         String urlSafe = url.toString().replaceFirst("[?].+$", "?…");
         try {
             AtomicReference<Throwable> lastError = new AtomicReference<>();
@@ -438,6 +438,8 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
                 throw (IOException) x2;
             } else if (x2 instanceof RuntimeException) {
                 throw (RuntimeException) x2;
+            } else if (x2 instanceof InterruptedException) {
+                throw (InterruptedException) x2;
             } else { // Error?
                 throw new RuntimeException(x);
             }

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
@@ -25,6 +25,7 @@
 package io.jenkins.plugins.artifact_manager_jclouds;
 
 import com.github.rholder.retry.Attempt;
+import com.github.rholder.retry.AttemptTimeLimiters;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -55,12 +56,14 @@ import com.github.rholder.retry.RetryListener;
 import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.StopStrategies;
 import com.github.rholder.retry.WaitStrategies;
+import com.google.common.util.concurrent.UncheckedTimeoutException;
 import hudson.AbortException;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
 import hudson.model.BuildListener;
+import hudson.model.Computer;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.remoting.VirtualChannel;
@@ -68,10 +71,13 @@ import hudson.slaves.WorkspaceList;
 import hudson.util.DirScanner;
 import hudson.util.io.ArchiverFactory;
 import io.jenkins.plugins.artifact_manager_jclouds.BlobStoreProvider.HttpMethod;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import jenkins.MasterToSlaveFileCallable;
 import jenkins.model.ArtifactManager;
+import jenkins.util.JenkinsJVM;
 import jenkins.util.VirtualFile;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.accmod.Restricted;
@@ -146,6 +152,7 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
         private final int stopAfterAttemptNumber = UPLOAD_STOP_AFTER_ATTEMPT_NUMBER;
         private final long waitMultiplier = UPLOAD_WAIT_MULTIPLIER;
         private final long waitMaximum = UPLOAD_WAIT_MAXIMUM;
+        private final long timeout = UPLOAD_TIMEOUT;
 
         UploadToBlobStorage(Map<String, URL> artifactUrls, TaskListener listener) {
             this.artifactUrls = artifactUrls;
@@ -157,7 +164,7 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
             for (Map.Entry<String, URL> entry : artifactUrls.entrySet()) {
                 Path local = f.toPath().resolve(entry.getKey());
                 URL url = entry.getValue();
-                uploadFile(local, url, listener, stopAfterAttemptNumber, waitMultiplier, waitMaximum);
+                uploadFile(local, url, listener, stopAfterAttemptNumber, waitMultiplier, waitMaximum, timeout);
             }
             return null;
         }
@@ -225,6 +232,7 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
         private final int stopAfterAttemptNumber = UPLOAD_STOP_AFTER_ATTEMPT_NUMBER;
         private final long waitMultiplier = UPLOAD_WAIT_MULTIPLIER;
         private final long waitMaximum = UPLOAD_WAIT_MAXIMUM;
+        private final long timeout = UPLOAD_TIMEOUT;
 
         Stash(URL url, String includes, String excludes, boolean useDefaultExcludes, String tempDir, TaskListener listener) throws IOException {
             this.url = url;
@@ -250,7 +258,7 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
                     throw new IOException(e);
                 }
                 if (count > 0) {
-                    uploadFile(tmp, url, listener, stopAfterAttemptNumber, waitMultiplier, waitMaximum);
+                    uploadFile(tmp, url, listener, stopAfterAttemptNumber, waitMultiplier, waitMaximum, timeout);
                 }
                 return count;
             } finally {
@@ -374,17 +382,23 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
      * Maximum number of seconds between upload attempts.
      */
     static long UPLOAD_WAIT_MAXIMUM = Long.getLong(JCloudsArtifactManager.class.getName() + ".UPLOAD_WAIT_MAXIMUM", 300);
+    /**
+     * Number of seconds to permit a single upload attempt to take.
+     */
+    static long UPLOAD_TIMEOUT = Long.getLong(JCloudsArtifactManager.class.getName() + ".UPLOAD_TIMEOUT", /* 15m */15 * 60);
+
+    private static final ExecutorService executors = JenkinsJVM.isJenkinsJVM() ? Computer.threadPoolForRemoting : Executors.newCachedThreadPool();
 
     /**
      * Upload a file to a URL
      */
     @SuppressWarnings("Convert2Lambda") // bogus use of generics (type variable should have been on class); cannot be made into a lambda
-    private static void uploadFile(Path f, URL url, final TaskListener listener, int stopAfterAttemptNumber, long waitMultiplier, long waitMaximum) throws IOException {
+    private static void uploadFile(Path f, URL url, final TaskListener listener, int stopAfterAttemptNumber, long waitMultiplier, long waitMaximum, long timeout) throws IOException {
         String urlSafe = url.toString().replaceFirst("[?].+$", "?…");
         try {
             AtomicReference<Throwable> lastError = new AtomicReference<>();
             RetryerBuilder.<Void>newBuilder().
-                    retryIfException(x -> x instanceof IOException && (!(x instanceof HTTPAbortException) || ((HTTPAbortException) x).code >= 500)).
+                    retryIfException(x -> x instanceof IOException && (!(x instanceof HTTPAbortException) || ((HTTPAbortException) x).code >= 500) || x instanceof UncheckedTimeoutException).
                     withRetryListener(new RetryListener() {
                         @Override
                         public <Void> void onRetry(Attempt<Void> attempt) {
@@ -395,7 +409,7 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
                     }).
                     withStopStrategy(StopStrategies.stopAfterAttempt(stopAfterAttemptNumber)).
                     withWaitStrategy(WaitStrategies.exponentialWait(waitMultiplier, waitMaximum, TimeUnit.SECONDS)).
-                    // TODO withAttemptTimeLimiter(…).
+                    withAttemptTimeLimiter(AttemptTimeLimiters.fixedTimeLimit(timeout, TimeUnit.SECONDS, executors)).
                     build().call(() -> {
                 Throwable t = lastError.get();
                 if (t != null) {

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/NetworkTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/NetworkTest.java
@@ -76,6 +76,7 @@ public class NetworkTest {
         WorkflowRun b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
         r.assertLogContains("/container/p/1/artifacts/f?…, response: 403 simulated 403 failure, body: Detailed explanation of 403.", b);
         r.assertLogNotContains("Retrying upload", b);
+        r.assertLogNotContains("\tat hudson.tasks.ArtifactArchiver.perform", b);
     }
 
     @Test
@@ -87,6 +88,7 @@ public class NetworkTest {
         WorkflowRun b = r.buildAndAssertSuccess(p);
         r.assertLogContains("/container/p/1/artifacts/f?…, response: 500 simulated 500 failure, body: Detailed explanation of 500.", b);
         r.assertLogContains("Retrying upload", b);
+        r.assertLogNotContains("\tat hudson.tasks.ArtifactArchiver.perform", b);
     }
 
     @Test
@@ -98,6 +100,7 @@ public class NetworkTest {
         WorkflowRun b = r.buildAndAssertSuccess(p);
         // currently prints a ‘java.net.SocketException: Connection reset’ but not sure if we really care
         r.assertLogContains("Retrying upload", b);
+        r.assertLogNotContains("\tat hudson.tasks.ArtifactArchiver.perform", b);
     }
 
 }

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/NetworkTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/NetworkTest.java
@@ -139,6 +139,12 @@ public class NetworkTest {
             WorkflowRun b = r.buildAndAssertSuccess(p);
             r.assertLogContains("Retrying upload", b);
             r.assertLogNotContains("\tat hudson.tasks.ArtifactArchiver.perform", b);
+            // Also from master:
+            hangIn(BlobStoreProvider.HttpMethod.PUT, "p/2/artifacts/f");
+            p.setDefinition(new CpsFlowDefinition("node('master') {writeFile file: 'f', text: '.'; archiveArtifacts 'f'}", true));
+            b = r.buildAndAssertSuccess(p);
+            r.assertLogContains("Retrying upload", b);
+            r.assertLogNotContains("\tat hudson.tasks.ArtifactArchiver.perform", b);
         } finally {
             JCloudsArtifactManager.UPLOAD_TIMEOUT = origTimeout;
         }


### PR DESCRIPTION
Continuing from #40.

- [X] errors from file upload (`archiveArtifacts`, `stash`)
- [x] endless errors from upload
- [x] hangs from upload
- [ ] interruption during upload (requires https://github.com/jenkinsci/workflow-step-api-plugin/pull/37)
- [ ] errors from file download (`unarchive`, `unstash`)
- [ ] hangs from download
- [ ] interruption during download
- [ ] errors/hangs/interruption during bucket list prior to `unarchive`
- [ ] errors/hangs/interruption during artifact/stash deletion/copy
- [ ] errors/hangs/interruption during master download (`*zip*` URLs)