### PR TITLE
[JENKINS-50520] Stop shading jclouds, update to 2.1.0, fix Guice & Guava issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.12</version>
+    <version>3.14</version>
     <relativePath />
   </parent>
   <groupId>io.jenkins.plugins</groupId>
@@ -16,7 +16,7 @@
   <properties>
     <revision>1.0-alpha-1</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jclouds.version>2.0.3</jclouds.version>
+    <jclouds.version>2.1.0</jclouds.version>
     <jenkins.version>2.121</jenkins.version>
     <java.level>8</java.level>
     <workflow-api-plugin.version>2.28-rc341.90cc5dc659de</workflow-api-plugin.version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/67 -->
@@ -41,41 +41,16 @@
   </scm>
 
   <dependencies>
-    <!-- shaded jclouds by the jclouds plugin -->
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>jclouds-shaded</artifactId>
-      <version>2.14</version>
-      <exclusions>
-        <!--
-        <exclusion>
-          <groupId>com.google.inject</groupId>
-          <artifactId>guice</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.inject.extensions</groupId>
-          <artifactId>guice-assistedinject</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.inject.extensions</groupId>
-          <artifactId>guice-multibindings</artifactId>
-        </exclusion>
-        -->
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>aws-java-sdk</artifactId>
-      <version>1.11.329</version>
-    </dependency>
-<!--
     <dependency>
       <groupId>org.apache.jclouds.provider</groupId>
       <artifactId>aws-s3</artifactId>
       <version>${jclouds.version}</version>
     </dependency>
--->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>aws-java-sdk</artifactId>
+      <version>1.11.329</version>
+    </dependency>
      <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
@@ -138,7 +113,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2.53</version>
+      <version>2.54-rc730.05bb1322341d</version> <!-- TODO https://github.com/jenkinsci/workflow-cps-plugin/pull/231 -->
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -174,6 +149,22 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.jenkins-ci.main</groupId>
+        <artifactId>jenkins-core</artifactId>
+        <version>${jenkins-core.version}</version>
+        <exclusions>
+          <exclusion> <!-- JENKINS-50520: pick up 18 from jclouds, which needs at least TypeToken (12+) -->
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency> <!-- JENKINS-50520: picked up from jclouds; to match the Guice version in core -->
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-assistedinject</artifactId>
+        <version>4.0</version>
+      </dependency>
+      <dependency>
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
         <version>2.8.1</version>
@@ -182,11 +173,6 @@
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
         <version>1.9</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.inject</groupId>
-        <artifactId>guice</artifactId>
-        <version>3.0</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -212,28 +198,11 @@
   <build>
       <plugins>
           <plugin>
-              <artifactId>maven-enforcer-plugin</artifactId>
-              <executions>
-                  <execution>
-                      <id>display-info</id>
-                      <configuration>
-                          <rules>
-                              <requireUpperBoundDeps>
-                                  <excludes combine.children="append">
-                                      <exclude>com.google.inject:guice</exclude> <!-- TODO jclouds classpath hell -->
-                                  </excludes>
-                              </requireUpperBoundDeps>
-                          </rules>
-                      </configuration>
-                  </execution>
-              </executions>
-          </plugin>
-
-          <plugin>
             <groupId>org.jenkins-ci.tools</groupId>
             <artifactId>maven-hpi-plugin</artifactId>
             <configuration>
-              <pluginFirstClassLoader>true</pluginFirstClassLoader>
+              <!-- JENKINS-50520: since we need a custom version of Guava -->
+              <maskClasses>com.google.common.</maskClasses>
             </configuration>
           </plugin>
 

--- a/src/main/java/io/jenkins/plugins/artifact_manager_s3/S3BlobStore.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_s3/S3BlobStore.java
@@ -62,7 +62,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import io.jenkins.plugins.artifact_manager_jclouds.BlobStoreProvider;
 import io.jenkins.plugins.artifact_manager_jclouds.BlobStoreProviderDescriptor;
-import shaded.com.google.common.base.Supplier;
+import com.google.common.base.Supplier;
 
 /**
  * Extension that customizes JCloudsBlobStore for AWS S3. Credentials are fetched from the environment, env vars, aws

--- a/src/test/java/io/jenkins/plugins/artifact_manager_s3/JCloudsVirtualFileTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_s3/JCloudsVirtualFileTest.java
@@ -55,7 +55,7 @@ import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 
 import jenkins.util.VirtualFile;
-import shaded.com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSet;
 
 public class JCloudsVirtualFileTest extends S3AbstractTest {
 


### PR DESCRIPTION
[JENKINS-50520](https://issues.jenkins-ci.org/browse/JENKINS-50520)

Adds a dep on https://github.com/jenkinsci/workflow-cps-plugin/pull/231.

Besides automated tests, I tried `mvn hpi:run` and also running in `java -jar jenkins.war` mode.