### PR TITLE
Fixing a flaky test

### DIFF
--- a/src/test/java/io/jenkins/plugins/artifact_manager_s3/JCloudsVirtualFileTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_s3/JCloudsVirtualFileTest.java
@@ -55,7 +55,6 @@ import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 
 import jenkins.util.VirtualFile;
-import shaded.com.google.common.collect.ImmutableSet;
 
 public class JCloudsVirtualFileTest extends S3AbstractTest {
 
@@ -179,8 +178,6 @@ public class JCloudsVirtualFileTest extends S3AbstractTest {
 
     @Test
     public void list() throws Exception {
-        VirtualFile[] rootList = root.list();
-        assertTrue("Expected list to contain files: " + Arrays.toString(rootList), rootList.length > 0);
         assertVirtualFileArrayEquals(new JCloudsVirtualFile[] { vf, weirdCharacters }, subdir.list());
         assertVirtualFileArrayEquals(new JCloudsVirtualFile[0], vf.list());
         assertVirtualFileArrayEquals(new JCloudsVirtualFile[0], missing.list());
@@ -191,15 +188,10 @@ public class JCloudsVirtualFileTest extends S3AbstractTest {
     public void listGlob() throws Exception {
         httpLogging.record(InvokeHttpMethod.class, Level.FINE);
         httpLogging.capture(1000);
-        String timestampDir = getPrefix().replaceFirst(".*/([^/?]+/)$", "$1");
-        assertEquals(ImmutableSet.of(timestampDir + weirdCharacters.getName(), timestampDir + vf.getName()),
-                subdir.getParent().list(timestampDir + "*", null, true));
-        int httpCount = httpLogging.getRecords().size();
-        System.err.println("total count: " + httpCount);
-        // TODO current count is 5, but this test is bad (nondeterministic)—lists files in the bucket not created by this test
-        // should rather create a directory with a specific number of files (enough to exceed a single iterator page!)
-        assertThat(httpCount, lessThanOrEqualTo(100));
-        assertArrayEquals(new String[] { vf.getName(), weirdCharacters.getName() }, subdir.list("**/**"));
+        assertThat(subdir.list("*", null, true), containsInAnyOrder(weirdCharacters.getName(), vf.getName()));
+        // TODO more interesting to create a directory with enough files to exceed a single iterator page:
+        assertEquals("calls GetBucketLocation then ListBucket", 2, httpLogging.getRecords().size());
+        assertThat(subdir.list("**/**"), arrayContainingInAnyOrder(vf.getName(), weirdCharacters.getName()));
         assertArrayEquals(new String[] { vf.getName() }, subdir.list(tmpFile.getName().substring(0, 4) + "*"));
         assertArrayEquals(new String[0], subdir.list("**/something**"));
         assertArrayEquals(new String[0], vf.list("**/**"));


### PR DESCRIPTION
On CI I saw a number of test flakes like

```
arrays first differed at element [0]; expected:<[junit326418646711570612.tmp]> but was:<[xxx#?:$'"<>čॐ]>
	at org.junit.internal.ComparisonCriteria.arrayEquals(ComparisonCriteria.java:55)
	at org.junit.Assert.internalArrayEquals(Assert.java:532)
	at org.junit.Assert.assertArrayEquals(Assert.java:283)
	at org.junit.Assert.assertArrayEquals(Assert.java:298)
	at io.jenkins.plugins.artifact_manager_s3.JCloudsVirtualFileTest.listGlob(JCloudsVirtualFileTest.java:202)
```

which just seems to have been due to the test needlessly asserting a particular order.

Also there was a longstanding issue with tests listing the `S3_DIR` (rather than the per-test timestamp dir) and expecting something about the results.