### PR TITLE
Fix bulk blob delete

### DIFF
--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
@@ -157,28 +157,7 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
             LOGGER.log(Level.FINE, "Ignoring blob deletion: {0}", blobPath);
             return false;
         }
-        return delete(provider, getContext().getBlobStore(), blobPath);
-    }
-
-    /**
-     * Delete all blobs starting with prefix
-     */
-    public static boolean delete(BlobStoreProvider provider, BlobStore blobStore, String prefix) throws IOException, InterruptedException {
-        try {
-            Iterator<StorageMetadata> it = new JCloudsVirtualFile.PageSetIterable(blobStore, provider.getContainer(), ListContainerOptions.Builder.prefix(prefix).recursive());
-            boolean found = false;
-            while (it.hasNext()) {
-                StorageMetadata sm = it.next();
-                String path = sm.getName();
-                assert path.startsWith(prefix);
-                LOGGER.fine("deleting " + path);
-                blobStore.removeBlob(provider.getContainer(), path);
-                found = true;
-            }
-            return found;
-        } catch (RuntimeException x) {
-            throw new IOException(x);
-        }
+        return JCloudsVirtualFile.delete(provider, getContext().getBlobStore(), blobPath);
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsVirtualFile.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsVirtualFile.java
@@ -402,4 +402,25 @@ public class JCloudsVirtualFile extends VirtualFile {
         return cacheFrames().stream().filter(frame -> key.startsWith(frame.root)).findFirst().orElse(null);
     }
 
+    /**
+     * Delete all blobs starting with a given prefix.
+     */
+    public static boolean delete(BlobStoreProvider provider, BlobStore blobStore, String prefix) throws IOException, InterruptedException {
+        try {
+            Iterator<StorageMetadata> it = new PageSetIterable(blobStore, provider.getContainer(), ListContainerOptions.Builder.prefix(prefix).recursive());
+            boolean found = false;
+            while (it.hasNext()) {
+                StorageMetadata sm = it.next();
+                String path = sm.getName();
+                assert path.startsWith(prefix);
+                LOGGER.fine("deleting " + path);
+                blobStore.removeBlob(provider.getContainer(), path);
+                found = true;
+            }
+            return found;
+        } catch (RuntimeException x) {
+            throw new IOException(x);
+        }
+    }
+
 }

--- a/src/test/java/io/jenkins/plugins/artifact_manager_s3/S3AbstractTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_s3/S3AbstractTest.java
@@ -26,7 +26,6 @@ package io.jenkins.plugins.artifact_manager_s3;
 
 import io.jenkins.plugins.artifact_manager_jclouds.BlobStoreProvider;
 import io.jenkins.plugins.artifact_manager_jclouds.JCloudsVirtualFile;
-import io.jenkins.plugins.artifact_manager_jclouds.JCloudsArtifactManager;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
@@ -123,7 +122,7 @@ public abstract class S3AbstractTest {
 
     @After
     public void deleteBlobs() throws Exception {
-        JCloudsArtifactManager.delete(provider, blobStore, prefix);
+        JCloudsVirtualFile.delete(provider, blobStore, prefix);
     }
 
 }


### PR DESCRIPTION
#42 introduced a regression in test cleanup, because `JCloudsArtifactManager.<clinit>` creates a `RobustHTTPClient`, which from `JCloudsVirtualFileTest` barfs since it is not running in a Jenkins master JVM.