### PR TITLE
Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.14</version>
+    <version>3.15</version>
     <relativePath />
   </parent>
   <groupId>io.jenkins.plugins</groupId>
@@ -17,9 +17,9 @@
     <revision>1.0-alpha-1</revision>
     <changelist>-SNAPSHOT</changelist>
     <jclouds.version>2.1.0</jclouds.version>
-    <jenkins.version>2.121</jenkins.version>
+    <jenkins.version>2.121.1</jenkins.version>
     <java.level>8</java.level>
-    <workflow-api-plugin.version>2.28-rc343.e9b9e0610374</workflow-api-plugin.version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/67 -->
+    <workflow-api-plugin.version>2.28</workflow-api-plugin.version>
     <useBeta>true</useBeta>
   </properties>
 
@@ -118,7 +118,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2.54-rc730.05bb1322341d</version> <!-- TODO https://github.com/jenkinsci/workflow-cps-plugin/pull/231 -->
+      <version>2.54-rc730.05bb1322341d</version> <!-- TODO pending release of https://github.com/jenkinsci/workflow-cps-plugin/pull/231 -->
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -130,7 +130,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
-      <version>2.8-rc353.ae434696120f</version> <!-- TODO https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/60 -->
+      <version>2.8-rc353.ae434696120f</version> <!-- TODO pending release of https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/60 -->
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -171,13 +171,13 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-step-api</artifactId>
-        <version>2.16-rc310.04f07c15faaf</version> <!-- TODO https://github.com/jenkinsci/workflow-step-api-plugin/pull/37 -->
+        <version>2.16-rc310.04f07c15faaf</version> <!-- TODO pending release of https://github.com/jenkinsci/workflow-step-api-plugin/pull/37 -->
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-support</artifactId>
-        <version>2.19-rc289.691fb60f3fa6</version> <!-- TODO https://github.com/jenkinsci/workflow-support-plugin/pull/61 -->
+        <version>2.19-rc289.691fb60f3fa6</version> <!-- TODO pending release of https://github.com/jenkinsci/workflow-support-plugin/pull/61 -->
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
-      <version>2.8-rc353.ae434696120f</version> <!-- TODO pending release of https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/60 -->
+      <version>2.9</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Have all the `compile`-scoped deps in MRP versions now:

```
Plugin-Dependencies: workflow-api:2.28,apache-httpcomponents-client-4-
 api:4.5.5-3.0,aws-java-sdk:1.11.329,structs:1.14
```