### PR TITLE
Updating test deps to released versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2.54-rc730.05bb1322341d</version> <!-- TODO pending release of https://github.com/jenkinsci/workflow-cps-plugin/pull/231 -->
+      <version>2.54</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -176,13 +176,13 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-step-api</artifactId>
-        <version>2.16-rc310.04f07c15faaf</version> <!-- TODO pending release of https://github.com/jenkinsci/workflow-step-api-plugin/pull/37 -->
+        <version>2.16</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-support</artifactId>
-        <version>2.19-rc289.691fb60f3fa6</version> <!-- TODO pending release of https://github.com/jenkinsci/workflow-support-plugin/pull/61 -->
+        <version>2.19</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Picks up releases of https://github.com/jenkinsci/workflow-cps-plugin/pull/231, https://github.com/jenkinsci/workflow-step-api-plugin/pull/37, & https://github.com/jenkinsci/workflow-support-plugin/pull/61.