### PR TITLE
Lock guava to 20.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,11 @@
         <version>2.2.7</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>20.0</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Otherwise 21.0 causes
`java.lang.NoSuchMethodError: com.google.common.util.concurrent.MoreExecutors.sameThreadExecutor()Lcom/google/common/util/concurrent/ListeningExecutorService;`

Broken with #62