### PR TITLE
[JENKINS-52361] Handling of empty stashes was incorrect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <jclouds.version>2.1.0</jclouds.version>
     <jenkins.version>2.121.1</jenkins.version>
     <java.level>8</java.level>
-    <workflow-api-plugin.version>2.28</workflow-api-plugin.version>
+    <workflow-api-plugin.version>2.29-rc313.bb1f9f990cbc</workflow-api-plugin.version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/75 -->
     <git-plugin.version>4.0.0-beta3</git-plugin.version>
     <workflow-multibranch-plugin.version>2.20</workflow-multibranch-plugin.version>
     <useBeta>true</useBeta>


### PR DESCRIPTION
[JENKINS-52361](https://issues.jenkins-ci.org/browse/JENKINS-52361)

Downstream of https://github.com/jenkinsci/workflow-api-plugin/pull/75. With `src/main/` reverted to `master`:

```
hudson.AbortException: No such saved stash ‘empty’ found at container/test1/1/stashes/empty.tgz
	at io.jenkins.plugins.artifact_manager_jclouds.JCloudsArtifactManager.unstash(JCloudsArtifactManager.java:237)
	at org.jenkinsci.plugins.workflow.flow.StashManager.unstash(StashManager.java:158)
	at org.jenkinsci.plugins.workflow.ArtifactManagerTest$StashFunction.apply(ArtifactManagerTest.java:269)
	at org.jenkinsci.plugins.workflow.ArtifactManagerTest.wrapInContainer(ArtifactManagerTest.java:125)
	at org.jenkinsci.plugins.workflow.ArtifactManagerTest.artifactStashAndDelete(ArtifactManagerTest.java:184)
	at io.jenkins.plugins.artifact_manager_jclouds.MockBlobStoreTest.smokes(MockBlobStoreTest.java:45)
```