### PR TITLE
[JENKINS-52304] Configuration-as-code support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>aws-global-configuration</artifactId>
-      <version>1.0-rc17.9e6f9170b20d</version> <!-- TODO -->
+      <version>1.0-rc20.980a9cfa0b14</version> <!-- TODO https://github.com/jenkinsci/aws-global-configuration-plugin/pull/4 -->
     </dependency>
     <dependency>
       <groupId>org.apache.jclouds.provider</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,12 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>0.10-alpha</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <dependencyManagement>
     <dependencies>

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManagerFactory.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManagerFactory.java
@@ -29,6 +29,7 @@ import hudson.model.Run;
 import jenkins.model.ArtifactManager;
 import jenkins.model.ArtifactManagerFactory;
 import jenkins.model.ArtifactManagerFactoryDescriptor;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -65,6 +66,7 @@ public class JCloudsArtifactManagerFactory extends ArtifactManagerFactory {
         return new JCloudsArtifactManager(build, provider);
     }
 
+    @Symbol("jclouds")
     @Extension
     public static final class DescriptorImpl extends ArtifactManagerFactoryDescriptor {
 

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStore.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStore.java
@@ -62,6 +62,7 @@ import hudson.Extension;
 import io.jenkins.plugins.artifact_manager_jclouds.BlobStoreProvider;
 import io.jenkins.plugins.artifact_manager_jclouds.BlobStoreProviderDescriptor;
 import io.jenkins.plugins.aws.global_configuration.CredentialsAwsGlobalConfiguration;
+import org.jenkinsci.Symbol;
 
 /**
  * Extension that customizes JCloudsBlobStore for AWS S3. Credentials are fetched from the environment, env vars, aws
@@ -198,6 +199,7 @@ public class S3BlobStore extends BlobStoreProvider {
         return builder.build().generatePresignedUrl(container, name, expiration, awsMethod);
     }
 
+    @Symbol("s3")
     @Extension
     public static final class DescriptorImpl extends BlobStoreProviderDescriptor {
 

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
@@ -50,12 +50,14 @@ import io.jenkins.plugins.artifact_manager_jclouds.JCloudsVirtualFile;
 import io.jenkins.plugins.aws.global_configuration.AbstractAwsGlobalConfiguration;
 import io.jenkins.plugins.aws.global_configuration.CredentialsAwsGlobalConfiguration;
 import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
 
 /**
  * Store the S3BlobStore configuration to save it on a separate file. This make that
  * the change of container does not affected to the Artifact functionality, you could change the container
  * and it would still work if both container contains the same data.
  */
+@Symbol("s3")
 @Extension
 public class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
 

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/ConfigAsCodeTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/ConfigAsCodeTest.java
@@ -33,6 +33,7 @@ import org.jenkinsci.plugins.casc.ConfigurationAsCode;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.Rule;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class ConfigAsCodeTest {
@@ -40,6 +41,7 @@ public class ConfigAsCodeTest {
     @Rule
     public JenkinsRule r = new JenkinsRule();
 
+    @Issue("JENKINS-52304")
     @Test
     public void smokes() throws Exception {
         ConfigurationAsCode.get().configure(ConfigAsCodeTest.class.getResource("configuration-as-code.yml").toString());

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/ConfigAsCodeTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/ConfigAsCodeTest.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package io.jenkins.plugins.artifact_manager_jclouds.s3;
+
+import io.jenkins.plugins.artifact_manager_jclouds.JCloudsArtifactManagerFactory;
+import io.jenkins.plugins.aws.global_configuration.CredentialsAwsGlobalConfiguration;
+import java.util.List;
+import jenkins.model.ArtifactManagerConfiguration;
+import jenkins.model.ArtifactManagerFactory;
+import org.jenkinsci.plugins.casc.ConfigurationAsCode;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class ConfigAsCodeTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void smokes() throws Exception {
+        ConfigurationAsCode.get().configure(ConfigAsCodeTest.class.getResource("configuration-as-code.yml").toString());
+        List<ArtifactManagerFactory> artifactManagerFactories = ArtifactManagerConfiguration.get().getArtifactManagerFactories();
+        assertEquals(1, artifactManagerFactories.size());
+        JCloudsArtifactManagerFactory mgr = (JCloudsArtifactManagerFactory) artifactManagerFactories.get(0);
+        assertEquals(S3BlobStore.class, mgr.getProvider().getClass());
+        assertEquals("us-east-1", CredentialsAwsGlobalConfiguration.get().getRegion());
+        assertEquals("jenkins_data/", S3BlobStoreConfig.get().getPrefix());
+    }
+
+}

--- a/src/test/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/configuration-as-code.yml
+++ b/src/test/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/configuration-as-code.yml
@@ -1,0 +1,12 @@
+---
+unclassified:
+  artifactManager:
+    artifactManagerFactories:
+      - JCloudsArtifactManagerFactory:
+          provider: s3blobstore
+Aws:
+  credentials:
+    region: "us-east-1"
+  s3blobstoreconfig:
+    container: "${ARTIFACT_MANAGER_S3_BUCKET_NAME}"
+    prefix: "jenkins_data/"

--- a/src/test/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/configuration-as-code.yml
+++ b/src/test/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/configuration-as-code.yml
@@ -2,11 +2,11 @@
 unclassified:
   artifactManager:
     artifactManagerFactories:
-      - JCloudsArtifactManagerFactory:
-          provider: s3blobstore
-Aws:
-  credentials:
+      - jclouds:
+          provider: s3
+aws:
+  awsCredentials:
     region: "us-east-1"
-  s3blobstoreconfig:
+  s3:
     container: "${ARTIFACT_MANAGER_S3_BUCKET_NAME}"
     prefix: "jenkins_data/"


### PR DESCRIPTION
[JENKINS-52304](https://issues.jenkins-ci.org/browse/JENKINS-52304)

Downstream of https://github.com/jenkinsci/aws-global-configuration-plugin/pull/4. Supersedes https://github.com/jenkinsci/configuration-as-code-plugin/pull/347, which may be closed. I expect to file a follow-up to https://github.com/jenkins-infra/evergreen/pull/139 once I get some questions answered by @batmat.