### PR TITLE
https://github.com/jenkinsci/workflow-api-plugin/pull/75 has been released

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <jclouds.version>2.1.0</jclouds.version>
     <jenkins.version>2.121.1</jenkins.version>
     <java.level>8</java.level>
-    <workflow-api-plugin.version>2.28</workflow-api-plugin.version> <!-- TODO 2.29 once https://github.com/jenkinsci/workflow-api-plugin/pull/75 is released -->
+    <workflow-api-plugin.version>2.29</workflow-api-plugin.version>
     <git-plugin.version>4.0.0-beta3</git-plugin.version>
     <workflow-multibranch-plugin.version>2.20</workflow-multibranch-plugin.version>
     <useBeta>true</useBeta>


### PR DESCRIPTION
Picks up the final version of https://github.com/jenkinsci/workflow-api-plugin/pull/75. The update in #71 had to be reverted to make this plugin releasable.