### PR TITLE
[JENKINS-51779] Test passes using 2.121.2+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.18</version>
+    <version>3.20</version>
     <relativePath />
   </parent>
   <groupId>io.jenkins.plugins</groupId>
@@ -17,7 +17,7 @@
     <revision>1.2</revision>
     <changelist>-SNAPSHOT</changelist>
     <jclouds.version>2.1.0</jclouds.version>
-    <jenkins.version>2.121.1</jenkins.version>
+    <jenkins.version>2.121.3</jenkins.version>
     <java.level>8</java.level>
     <workflow-api-plugin.version>2.29</workflow-api-plugin.version>
     <git-plugin.version>4.0.0-beta3</git-plugin.version>

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/NetworkTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/NetworkTest.java
@@ -48,7 +48,6 @@ import org.jenkinsci.plugins.workflow.steps.TimeoutStepExecution;
 import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
@@ -325,7 +324,6 @@ public class NetworkTest {
         r.assertLogContains(new TimeoutStepExecution.ExceededTimeout().getShortDescription(), r.assertBuildStatus(Result.ABORTED, p.scheduleBuild2(0)));
     }
 
-    @Ignore("TODO JENKINS-51779 Iterators.skip linkage error since Guava 18 is in test classpath")
     @Test
     public void errorCleaningArtifacts() throws Exception {
         loggerRule.record(WorkflowRun.class, Level.WARNING).capture(10);


### PR DESCRIPTION
Restoring test suppressed in #44 by picking up https://github.com/jenkinsci/jenkins/pull/3481.