### PR TITLE
Re-enable GetBucketLocation tests and add validation

### DIFF
--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/JCloudsArtifactManagerTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/JCloudsArtifactManagerTest.java
@@ -44,7 +44,6 @@ import org.jenkinsci.test.acceptance.docker.DockerImage;
 import org.jenkinsci.test.acceptance.docker.fixtures.JavaContainer;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
@@ -202,7 +201,6 @@ public class JCloudsArtifactManagerTest extends S3AbstractTest {
         }
     }
 
-    @Ignore("TODO fails in CI but not locally: S3HttpApiModule.bucketToRegion cache is not working")
     @Test
     public void artifactBrowsingPerformance() throws Exception {
         ArtifactManagerConfiguration.get().getArtifactManagerFactories().add(getArtifactManagerFactory(null, null));

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/JCloudsVirtualFileTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/JCloudsVirtualFileTest.java
@@ -46,7 +46,6 @@ import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
 import org.jclouds.rest.internal.InvokeHttpMethod;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -196,7 +195,6 @@ public class JCloudsVirtualFileTest extends S3AbstractTest {
         assertArrayEquals(new String[0], missing.list("**/**"));
     }
 
-    @Ignore("TODO fails in CI but not locally: S3HttpApiModule.bucketToRegion cache is not working")
     @Test
     public void pagedListing() throws Exception {
         for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
It was determined that the multiple calls to GetBucketLocation were as a result of the role under which the CI tests were being executed not having the relevant permission. This was resulting in a 403 on the call to GetBucketLocation. This doesn't cause anything to fail from a plugin perspective but the result is not cached so the call is made repeatedly when attempting to resolve the location for each of the items in the bucket.

Having added the required permission to the CI's role, re-enabling the tests. Adding an additional check to the plugin validation that outputs a warning if a successful call to GetBucketLocation cannot be made. The warning text "GetBucketLocation failed" is added as, in the case of a lack of permissions, the error from S3 just indicates "AccessDenied", not what operation was being performed at the time.