### PR TITLE
Java 11 readiness: Build on recommended variations (Linux only)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,9 @@
 if (infra.isRunningOnJenkinsInfra()) {
     // ci.jenkins.io
-    buildPlugin(platforms: ['linux'])
+    buildPlugin(configurations: [
+    [ platform: "linux", jdk: "8", jenkins: null ],
+    [ platform: "linux", jdk: "8",  jenkins: "2.164.1", javaLevel: "8" ],
+    ])
 } else if (env.CHANGE_FORK == null) { // TODO pending JENKINS-45970
     // to run tests on S3
     buildArtifactManagerPluginOnAWS()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@ if (infra.isRunningOnJenkinsInfra()) {
     buildPlugin(configurations: [
     [ platform: "linux", jdk: "8", jenkins: null ],
     [ platform: "linux", jdk: "8",  jenkins: "2.164.1", javaLevel: "8" ],
+    [ platform: "linux", jdk: "11", jenkins: "2.164.1", javaLevel: "8" ],
     ])
 } else if (env.CHANGE_FORK == null) { // TODO pending JENKINS-45970
     // to run tests on S3

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,10 @@
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-io</groupId> <!-- take version from Jenkins Core -->
+          <artifactId>commons-io</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -340,5 +340,22 @@
               </plugins>
           </build>
       </profile>
+      <profile>
+          <id>add-jaxb-api-pluginjdk-11</id>
+          <activation>
+              <property>
+                  <name>java.specification.version</name>
+                  <value>11</value>
+              </property>
+          </activation>
+          <dependencies>
+              <dependency>
+                  <groupId>io.jenkins.plugins</groupId>
+                  <artifactId>jaxb</artifactId>
+                  <version>2.3.0</version>
+                  <scope>test</scope>
+              </dependency>
+          </dependencies>
+      </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <jclouds.version>2.1.1</jclouds.version>
     <jenkins.version>2.121.3</jenkins.version>
     <java.level>8</java.level>
-    <workflow-api-plugin.version>2.29</workflow-api-plugin.version>
+    <workflow-api-plugin.version>2.33</workflow-api-plugin.version>
     <git-plugin.version>4.0.0-rc</git-plugin.version>
     <workflow-multibranch-plugin.version>2.20</workflow-multibranch-plugin.version>
     <useBeta>true</useBeta>
@@ -79,7 +79,7 @@
     <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>structs</artifactId>
-        <version>1.14</version>
+        <version>1.17</version>
     </dependency>
     <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -261,13 +261,13 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-step-api</artifactId>
-        <version>2.16</version>
+        <version>2.19</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-support</artifactId>
-        <version>2.19</version>
+        <version>3.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -352,7 +352,7 @@
               <dependency>
                   <groupId>io.jenkins.plugins</groupId>
                   <artifactId>jaxb</artifactId>
-                  <version>2.3.0</version>
+                  <version>2.3.0.1</version>
                   <scope>test</scope>
               </dependency>
           </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.37</version>
+    <version>3.40</version>
     <relativePath />
   </parent>
   <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
For Java 11 readiness, apply recommended configuration:
https://wiki.jenkins.io/display/JENKINS/Java+11+Developer+Guidelines#Java11DeveloperGuidelines-MakesureyourpluginistestedinContinuousIntegrationonJava8andJava11atthesametime

And fixing what was revealed through this.

@jenkinsci/java11-support for review.