### PR TITLE
[WIP] Revert "Add the JAXB API plugin during tests when on JDK 11"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <revision>1.4</revision>
     <changelist>-SNAPSHOT</changelist>
     <jclouds.version>2.1.1</jclouds.version>
-    <jenkins.version>2.121.3</jenkins.version>
+    <jenkins.version>2.164.1</jenkins.version>
     <java.level>8</java.level>
     <workflow-api-plugin.version>2.33</workflow-api-plugin.version>
     <git-plugin.version>4.0.0-rc</git-plugin.version>
@@ -231,7 +231,7 @@
     <dependency>
         <groupId>io.jenkins.plugins</groupId>
         <artifactId>jaxb</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.0.1</version>
         <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,12 @@
       <version>0.10-alpha</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>jaxb</artifactId>
+        <version>2.3.0</version>
+        <scope>test</scope>
+    </dependency>
   </dependencies>
   <dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -340,22 +340,5 @@
               </plugins>
           </build>
       </profile>
-      <profile>
-          <id>add-jaxb-api-pluginjdk-11</id>
-          <activation>
-              <property>
-                  <name>java.specification.version</name>
-                  <value>11</value>
-              </property>
-          </activation>
-          <dependencies>
-              <dependency>
-                  <groupId>io.jenkins.plugins</groupId>
-                  <artifactId>jaxb</artifactId>
-                  <version>2.3.0.1</version>
-                  <scope>test</scope>
-              </dependency>
-          </dependencies>
-      </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Followup for #87 proposing an alternate fix.

 This reverts commits:
* 341d5e0f3c22aca14ca9091d6b2b07339dce0095 and
* 8331f44f7f54f60fc6652983fe4bee6ee78bd610.

EXPECTED TO FAIL