### PR TITLE
[WIP] Update workflow-job dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
-      <version>2.25</version>
+      <version>2.26</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
-      <version>2.21</version>
+      <version>2.25</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Test failure surfaced during testing from 2.25 to 2.26 locally. Trying to show this in a PR, IOW in a "clean" environment.

When bumping workflow-job from 2.25 to 2.26:
```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 24.082 s <<< FAILURE! - in io.jenkins.plugins.artifact_manager_jclouds.NetworkTest
[ERROR] repeatedRecoverableErrorUnstashing(io.jenkins.plugins.artifact_manager_jclouds.NetworkTest)  Time elapsed: 23.303 s  <<< FAILURE!
java.lang.AssertionError: 

Expected: a string containing "Retrying download"
     but: was "Started
Running in Durability level: MAX_SURVIVABILITY
[Pipeline] node
Running on remote in /home/tiste/dev/github/jenkinsci/artifact-manager-s3-plugin/target/tmp/j h8761481906439906155/workspace/p
[Pipeline] {
[Pipeline] writeFile
[Pipeline] stash
Stashed 1 file(s) to mock://container/p/1/stashes/f.tgz
[Pipeline] unstash
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
ERROR: Failed to download http://0.0.0.0:39605/container/p/1/stashes/f.tgz?… into /home/tiste/dev/github/jenkinsci/artifact-manager-s3-plugin/target/tmp/j h8761481906439906155/workspace/p, response: 500 simulated 500 failure, body: Detailed explanation of 500.
Finished: FAILURE
"
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.junit.Assert.assertThat(Assert.java:956)
        at org.junit.Assert.assertThat(Assert.java:923)
        at org.jvnet.hudson.test.JenkinsRule.assertLogContains(JenkinsRule.java:1259)
        at io.jenkins.plugins.artifact_manager_jclouds.NetworkTest.repeatedRecoverableErrorUnstashing(NetworkTest.java:237)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
        at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:554)
        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.lang.Thread.run(Thread.java:748)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   NetworkTest.repeatedRecoverableErrorUnstashing:237 
Expected: a string containing "Retrying download"
     but: was "Started
Running in Durability level: MAX_SURVIVABILITY
[Pipeline] node
Running on remote in /home/tiste/dev/github/jenkinsci/artifact-manager-s3-plugin/target/tmp/j h8761481906439906155/workspace/p
[Pipeline] {
[Pipeline] writeFile
[Pipeline] stash
Stashed 1 file(s) to mock://container/p/1/stashes/f.tgz
[Pipeline] unstash
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
ERROR: Failed to download http://0.0.0.0:39605/container/p/1/stashes/f.tgz?… into /home/tiste/dev/github/jenkinsci/artifact-manager-s3-plugin/target/tmp/j h8761481906439906155/workspace/p, response: 500 simulated 500 failure, body: Detailed explanation of 500.
Finished: FAILURE
"
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 
```