### PR TITLE
No need to bundle jsr305.jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,12 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>aws-credentials</artifactId>
       <version>1.26</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Noticed thanks to https://github.com/jenkinsci/maven-hpi-plugin/pull/130. Otherwise this actually comes in via the `test` dep on `docker-fixtures`, yet is in `compile` scope.