### PR TITLE
JENKINS-50772: specify content type for uploaded files in S3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
-      <version>4.5.5-3.0</version>
+      <version>4.5.10-2.0</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStore.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStore.java
@@ -55,6 +55,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import com.amazonaws.auth.AWSSessionCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.google.common.base.Supplier;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -185,10 +186,13 @@ public class S3BlobStore extends BlobStoreProvider {
         String name = blob.getMetadata().getName();
         LOGGER.log(Level.FINE, "Generating presigned URL for {0} / {1} for method {2}",
                 new Object[] { container, name, httpMethod });
+        String contentType = null;
         com.amazonaws.HttpMethod awsMethod;
         switch (httpMethod) {
         case PUT:
             awsMethod = com.amazonaws.HttpMethod.PUT;
+            // Only set content type for upload URLs, so that the right S3 metadata gets set
+            contentType = blob.getMetadata().getContentMetadata().getContentType();
             break;
         case GET:
             awsMethod = com.amazonaws.HttpMethod.GET;
@@ -196,7 +200,13 @@ public class S3BlobStore extends BlobStoreProvider {
         default:
             throw new IOException("HTTP Method " + httpMethod + " not supported for S3");
         }
-        return builder.build().generatePresignedUrl(container, name, expiration, awsMethod);
+
+        GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(container, name)
+            .withExpiration(expiration)
+            .withMethod(awsMethod)
+            .withContentType(contentType);
+
+        return builder.build().generatePresignedUrl(generatePresignedUrlRequest);
     }
 
     @Symbol("s3")

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/JCloudsArtifactManagerTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/JCloudsArtifactManagerTest.java
@@ -54,6 +54,7 @@ import org.jvnet.hudson.test.TestBuilder;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.cloudbees.hudson.plugins.folder.Folder;
+import com.gargoylesoftware.htmlunit.WebResponse;
 
 import hudson.FilePath;
 import hudson.Launcher;
@@ -304,6 +305,85 @@ public class JCloudsArtifactManagerTest extends S3AbstractTest {
         assertThat(j.createWebClient().withBasicCredentials("admin").goTo(url, jsonType).getWebResponse().getContentAsString(), containsString(snippet));
         j.createWebClient().withBasicCredentials("dev1").assertFails(url, 404);
         assertThat(j.createWebClient().withBasicCredentials("dev2").goTo(url, jsonType).getWebResponse().getContentAsString(), containsString(snippet));
+    }
+
+    @Issue("JENKINS-50772")
+    @Test
+    public void contentTypeText() throws Exception {
+        final String expectedContents = "some regular text";
+        final String expectedContentType = "text/plain";
+
+        CredentialsAwsGlobalConfiguration.get().setCredentialsId("bogus"); // force sessionCredentials to call getCredentials
+        ArtifactManagerConfiguration.get().getArtifactManagerFactories().add(getArtifactManagerFactory(null, null));
+
+        WorkflowJob p = j.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("node {writeFile file: 'f.txt', text: '" + expectedContents + "'; archiveArtifacts 'f.txt'}", true));
+        j.buildAndAssertSuccess(p);
+
+        String url = "job/p/1/artifact/f.txt";
+        WebResponse response = j.createWebClient().goTo(url, null).getWebResponse();
+        assertThat(response.getContentAsString(), equalTo(expectedContents));
+        assertThat(response.getContentType(), equalTo(expectedContentType));
+    }
+
+    @Issue("JENKINS-50772")
+    @Test
+    public void contentTypeHtml() throws Exception {
+        final String expectedContents = "<html><header></header><body>Test file contents</body></html>";
+        final String expectedContentType = "text/html";
+
+        CredentialsAwsGlobalConfiguration.get().setCredentialsId("bogus"); // force sessionCredentials to call getCredentials
+        ArtifactManagerConfiguration.get().getArtifactManagerFactories().add(getArtifactManagerFactory(null, null));
+
+        WorkflowJob p = j.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("node {writeFile file: 'f.html', text: '" + expectedContents + "'; archiveArtifacts 'f.html'}", true));
+        j.buildAndAssertSuccess(p);
+
+        String url = "job/p/1/artifact/f.html";
+        WebResponse response = j.createWebClient().goTo(url, null).getWebResponse();
+        assertThat(response.getContentAsString(), equalTo(expectedContents));
+        assertThat(response.getContentType(), equalTo(expectedContentType));
+    }
+
+    @Issue("JENKINS-50772")
+    @Test
+    public void contentTypeUnknown() throws Exception {
+        final String expectedContents = "";
+        final String expectedContentType = "binary/octet-stream";
+
+        CredentialsAwsGlobalConfiguration.get().setCredentialsId("bogus"); // force sessionCredentials to call getCredentials
+        ArtifactManagerConfiguration.get().getArtifactManagerFactories().add(getArtifactManagerFactory(null, null));
+
+        WorkflowJob p = j.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("node {writeFile file: 'f', text: '" + expectedContents + "'; archiveArtifacts 'f'}", true));
+        j.buildAndAssertSuccess(p);
+
+        String url = "job/p/1/artifact/f";
+        WebResponse response = j.createWebClient().goTo(url, null).getWebResponse();
+        assertThat(response.getContentAsString(), equalTo(expectedContents));
+        assertThat(response.getContentType(), equalTo(expectedContentType));
+    }
+
+    @Issue("JENKINS-50772")
+    @Test
+    public void stashInS3() throws Exception {
+        CredentialsAwsGlobalConfiguration.get().setCredentialsId("bogus"); // force sessionCredentials to call getCredentials
+        ArtifactManagerConfiguration.get().getArtifactManagerFactories().add(getArtifactManagerFactory(null, null));
+
+        WorkflowJob p = j.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+            "node {" +
+            "  def expected = 'some text';" +
+            "  writeFile file: 'f.txt', text: expected;" +
+            "  stash name: 'test-stash', includes: 'f.txt';" +
+            "  sh 'rm f.txt';" +
+            "  if (fileExists('f.txt')) error 'File should not exist anymore';" +
+            "  unstash name: 'test-stash';" +
+            "  def actual = readFile file: 'f.txt';" +
+            "  if (actual != expected) error 'Stashed file has wrong contents';" +
+            "}",
+            true));
+        j.buildAndAssertSuccess(p);
     }
 
     //@Test


### PR DESCRIPTION
[JENKINS-50772](https://issues.jenkins-ci.org/browse/JENKINS-50772): specify content type for uploaded files in S3, where one could be determined.

As far as determining the appropriate content for a given file, at first `java.nio.Files#probeContentType()` is called to see if that returns a non-null content type. If unsuccessful, `java.net.URLConnection#guessContentTypeFromName()` is used to pick a content type based on the file extension. For each file in the list of artifacts to be uploaded, the content type (if any) is recorded in a separate map. Additionally, the content type is passed in to the S3BlobStore method which calculates the presigned URL since the content-type header is part of the signed URL and needs to be known before generating the URL. Next, during the loop which uploads the artifacts to S3, the recorded content types for each file (again, if any was able to be determined for a given file) are retrieved and passed in to the RobustHTTPClient's `uploadFile` call.

In S3BlobStore, we need to use `GeneratePresignedUrlRequest` to generate the presigned URL as it allows us to specify the "Content-Type" header in the generated URL. The existing `AmazonS3ClientBuilder` does not provide this option.

This requires a change to RobustHTTPClient to accept a content type parameter for an uploaded file. I have created a separate pull request for that, which is at https://github.com/jenkinsci/apache-httpcomponents-client-4-api-plugin/pull/24.