### PR TITLE
[JENKINS-60040] Update to jclouds 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,6 @@
   <properties>
     <revision>1.7</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jclouds.version>2.1.1</jclouds.version>
     <jenkins.version>2.164.2</jenkins.version>
     <java.level>8</java.level>
     <workflow-api-plugin.version>2.33</workflow-api-plugin.version>
@@ -52,7 +51,7 @@
     <dependency>
       <groupId>org.apache.jclouds.provider</groupId>
       <artifactId>aws-s3</artifactId>
-      <version>${jclouds.version}</version>
+      <version>2.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/MockApiMetadata.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/MockApiMetadata.java
@@ -30,6 +30,7 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.io.IOUtils;
 import org.jclouds.apis.ApiMetadata;
@@ -196,7 +197,8 @@ public final class MockApiMetadata extends BaseApiMetadata {
                 handler.run();
                 throw new AssertionError("not supposed to get here");
             }
-            return () -> blobsByContainer.get(container).keySet().stream().filter(path -> path.startsWith(prefix)).iterator();
+            Set<String> keys = blobsByContainer.get(container).keySet();
+            return prefix == null ? keys : () -> keys.stream().filter(path -> path.startsWith(prefix)).iterator();
         }
 
         @Override

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/MockApiMetadata.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/MockApiMetadata.java
@@ -31,7 +31,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Logger;
 import org.apache.commons.io.IOUtils;
 import org.jclouds.apis.ApiMetadata;
 import org.jclouds.apis.internal.BaseApiMetadata;
@@ -64,8 +63,6 @@ import org.kohsuke.MetaInfServices;
  */
 @MetaInfServices(ApiMetadata.class)
 public final class MockApiMetadata extends BaseApiMetadata {
-
-    private static final Logger LOGGER = Logger.getLogger(MockApiMetadata.class.getName());
 
     public MockApiMetadata() {
         this(new Builder());
@@ -122,7 +119,7 @@ public final class MockApiMetadata extends BaseApiMetadata {
 
     @FunctionalInterface
     interface GetBlobKeysInsideContainerHandler {
-        Iterable<String> run() throws IOException;
+        void run() throws IOException;
     }
 
     private static final Map<String, GetBlobKeysInsideContainerHandler> getBlobKeysInsideContainerHandlers = new ConcurrentHashMap<>();
@@ -193,12 +190,13 @@ public final class MockApiMetadata extends BaseApiMetadata {
         }
 
         @Override
-        public Iterable<String> getBlobKeysInsideContainer(String container) throws IOException {
+        public Iterable<String> getBlobKeysInsideContainer(String container, String prefix) throws IOException {
             GetBlobKeysInsideContainerHandler handler = getBlobKeysInsideContainerHandlers.remove(container);
             if (handler != null) {
-                return handler.run();
+                handler.run();
+                throw new AssertionError("not supposed to get here");
             }
-            return blobsByContainer.get(container).keySet();
+            return () -> blobsByContainer.get(container).keySet().stream().filter(path -> path.startsWith(prefix)).iterator();
         }
 
         @Override

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/NetworkTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/NetworkTest.java
@@ -315,7 +315,6 @@ public class NetworkTest {
         MockApiMetadata.handleGetBlobKeysInsideContainer("container", () -> {
             try {
                 Thread.sleep(Long.MAX_VALUE);
-                return null; // to satisfy compiler
             } catch (InterruptedException x) {
                 throw new RuntimeException(x);
             }

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/JCloudsArtifactManagerTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/JCloudsArtifactManagerTest.java
@@ -189,12 +189,12 @@ public class JCloudsArtifactManagerTest extends S3AbstractTest {
 
     @Test
     public void artifactStash() throws Exception {
-        ArtifactManagerTest.artifactStash(j, getArtifactManagerFactory(null, null), /* TODO true → 400: Unsupported copy source parameter. Re-enable once JCLOUDS-1447 released. */false, image);
+        ArtifactManagerTest.artifactStash(j, getArtifactManagerFactory(null, null), true, image);
     }
 
     @Test
     public void artifactStashAndDelete() throws Exception {
-        ArtifactManagerTest.artifactStashAndDelete(j, getArtifactManagerFactory(null, true), /* TODO ditto */false, image);
+        ArtifactManagerTest.artifactStashAndDelete(j, getArtifactManagerFactory(null, true), true, image);
     }
 
     private static final class LoadS3Credentials extends MasterToSlaveCallable<Void, RuntimeException> {


### PR DESCRIPTION
Mainly to pick up [JCLOUDS-1447](https://jira.apache.org/jira/browse/JCLOUDS-1447) https://github.com/jclouds/jclouds/pull/1238, fixing various problems with special characters such as [JENKINS-60040](https://issues.jenkins-ci.org/browse/JENKINS-60040), but see [full release notes](https://jclouds.apache.org/releasenotes/2.2.0/).

Supersedes #99.