### PR TITLE
Fix for aws-java-sdk 1.11.723

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,12 +254,12 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>aws-java-sdk</artifactId>
-        <version>1.11.700</version>
+        <version>1.11.723</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>jackson2-api</artifactId>
-        <version>2.10.1</version>
+        <version>2.10.2</version>
       </dependency>
       <dependency>
         <groupId>joda-time</groupId>

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
@@ -24,8 +24,6 @@
 
 package io.jenkins.plugins.artifact_manager_jclouds.s3;
 
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.Protocol;
 import java.io.IOException;
 import java.util.regex.Pattern;
 
@@ -261,7 +259,7 @@ public class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
             if (StringUtils.isBlank(resolvedCustomSigningRegion)) {
                 resolvedCustomSigningRegion = "us-east-1";
             }
-            ret = ret.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(customEndpoint, resolvedCustomSigningRegion));
+            ret = ret.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(getResolvedCustomEndpoint(), resolvedCustomSigningRegion));
         } else if (StringUtils.isNotBlank(CredentialsAwsGlobalConfiguration.get().getRegion())) {
             ret = ret.withRegion(CredentialsAwsGlobalConfiguration.get().getRegion());
         } else {
@@ -271,9 +269,6 @@ public class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
         // TODO the client would automatically use path-style URLs under certain conditions; is it really necessary to override?
         ret = ret.withPathStyleAccessEnabled(getUsePathStyleUrl());
 
-        if (getUseHttp()) {
-            ret = ret.withClientConfiguration(new ClientConfiguration().withProtocol(Protocol.HTTP));
-        }
         return ret;
     }
 


### PR DESCRIPTION
At least integration tests were broken by a regression in the SDK. That is fixed in https://github.com/aws/aws-sdk-java/pull/2256, but this is probably better anyway.