### PR TITLE
Modified S3 uploads to be done in parallel

### DIFF
--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
@@ -55,6 +55,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.MasterToSlaveFileCallable;
@@ -121,19 +122,23 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
         LOGGER.log(Level.FINE, "Archiving from {0}: {1}", new Object[] { workspace, artifacts });
         Map<String, String> contentTypes = workspace.act(new ContentTypeGuesser(new ArrayList<>(artifacts.keySet()), listener));
         LOGGER.fine(() -> "guessing content types: " + contentTypes);
-        Map<String, URL> artifactUrls = new HashMap<>();
+        Map<String, URL> artifactUrls = new ConcurrentHashMap<>();
         BlobStore blobStore = getContext().getBlobStore();
-
-        // Map artifacts to urls for upload
-        for (Map.Entry<String, String> entry : artifacts.entrySet()) {
+ // Map artifacts to urls for upload
+        artifacts.entrySet().parallelStream().forEach(entry -> {
+            try{
             String path = "artifacts/" + entry.getKey();
             String blobPath = getBlobPath(path);
             Blob blob = blobStore.blobBuilder(blobPath).build();
             blob.getMetadata().setContainer(provider.getContainer());
             blob.getMetadata().getContentMetadata().setContentType(contentTypes.get(entry.getKey()));
             artifactUrls.put(entry.getValue(), provider.toExternalURL(blob, HttpMethod.PUT));
-        }
-
+            }
+            catch (Exception e) {
+                // at the very least you want to log the exception, otherwise debugging will be difficult
+                listener.getLogger().printf("ERROR in artifacts:  %s artifact \n", e);
+              }
+        });
         workspace.act(new UploadToBlobStorage(artifactUrls, contentTypes, listener));
         listener.getLogger().printf("Uploaded %s artifact(s) to %s%n", artifactUrls.size(), provider.toURI(provider.getContainer(), getBlobPath("artifacts/")));
     }
@@ -185,13 +190,15 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
 
         @Override
         public Void invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
-            try {
-                for (Map.Entry<String, URL> entry : artifactUrls.entrySet()) {
-                    client.uploadFile(new File(f, entry.getKey()), contentTypes.get(entry.getKey()), entry.getValue(), listener);
-                }
-            } finally {
-                listener.getLogger().flush();
-            }
+            artifactUrls.entrySet().parallelStream().forEach(entry -> {  // entry is a Map.Entry<String, URL>
+              try {
+                client.uploadFile(new File(f, entry.getKey()), contentTypes.get(entry.getKey()), entry.getValue(), listener);
+              } catch (Exception e) {
+                // at the very least you want to log the exception, otherwise debugging will be hard
+                  listener.getLogger().printf("ERROR in invoke (upload):  %s artifact \n", e);
+              }
+            });
+            listener.getLogger().flush();
             return null;
         }
     }


### PR DESCRIPTION
I've modified a few of the S3 functions to use  parallelstream() vs the for loop this should improve upload times drastically.  I saw a drop from 26 mins to 9 mins for 10,000  5KB files.  
Jenkins issue JENKINS-61936  https://issues.jenkins-ci.org/browse/JENKINS-61936