### PR TITLE
Tracked down test flake

### DIFF
--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/NetworkTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/NetworkTest.java
@@ -34,19 +34,18 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
-import java.util.stream.Collectors;
 import jenkins.model.ArtifactManagerConfiguration;
 import org.apache.http.ConnectionClosedException;
 import org.apache.http.HttpVersion;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicStatusLine;
-import static org.hamcrest.Matchers.*;
 import org.jclouds.blobstore.ContainerNotFoundException;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.TimeoutStepExecution;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -333,8 +332,7 @@ public class NetworkTest {
         p.setBuildDiscarder(new LogRotator(-1, -1, -1, 0));
         MockApiMetadata.handleRemoveBlob("container", "p/1/artifacts/f", () -> {throw new ContainerNotFoundException("container", "sorry about your artifacts");});
         r.buildAndAssertSuccess(p);
-        assertThat(loggerRule.getRecords().stream().map(LogRecord::getThrown).filter(Objects::nonNull).map(Functions::printThrowable).collect(Collectors.joining("\n")),
-            containsString("container not found: sorry about your artifacts"));
+        expectLogMessage("container not found: sorry about your artifacts");
     }
 
     @Test
@@ -344,8 +342,7 @@ public class NetworkTest {
         p.setDefinition(new CpsFlowDefinition("node('remote') {writeFile file: 'f', text: '.'; stash 'stuff'}", true));
         MockApiMetadata.handleRemoveBlob("container", "p/1/stashes/stuff.tgz", () -> {throw new ContainerNotFoundException("container", "sorry about your stashes");});
         r.buildAndAssertSuccess(p);
-        assertThat(loggerRule.getRecords().stream().map(LogRecord::getThrown).filter(Objects::nonNull).map(Functions::printThrowable).collect(Collectors.joining("\n")),
-            containsString("container not found: sorry about your stashes"));
+        expectLogMessage("container not found: sorry about your stashes");
     }
 
     // Interrupts probably never delivered during HTTP requests (maybe depends on servlet container?).
@@ -361,8 +358,7 @@ public class NetworkTest {
             System.err.println("build root");
             loggerRule.record(Run.class, Level.WARNING).capture(10);
             wc.getPage(b);
-            assertThat(loggerRule.getRecords().stream().map(LogRecord::getThrown).filter(Objects::nonNull).map(Functions::printThrowable).collect(Collectors.joining("\n")),
-                containsString("container not found: sorry"));
+            expectLogMessage("container not found: sorry");
         }
         {
             System.err.println("artifact root");
@@ -376,10 +372,15 @@ public class NetworkTest {
                 String responseText = x.getResponse().getContentAsString();
                 String expectedError = "container not found: really sorry";
                 if (!responseText.contains(expectedError)) { // Jenkins 2.224+
-                    assertThat(responseText, loggerRule.getRecords().stream().map(LogRecord::getThrown).filter(Objects::nonNull).map(Functions::printThrowable).collect(Collectors.joining("\n")),
-                            containsString(expectedError));
+                    expectLogMessage(expectedError);
                 }
             }
+        }
+    }
+
+    private void expectLogMessage(String message) throws InterruptedException {
+        while (loggerRule.getRecords().stream().map(LogRecord::getThrown).filter(Objects::nonNull).map(Functions::printThrowable).noneMatch(t -> t.contains(message))) {
+            Thread.sleep(100);
         }
     }
 


### PR DESCRIPTION
https://github.com/jenkinsci/workflow-job-plugin/blob/ded785da2ac68b9ecdd53dab426197fea28bd990/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java#L618-L620 meant that

```diff
diff --git src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
index f6ee5e1..3c37815 100644
--- src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
+++ src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
@@ -203,6 +203,7 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
             LOGGER.log(Level.FINE, "Ignoring blob deletion: {0}", blobPath);
             return false;
         }
+        Thread.sleep(1000);
         return JCloudsVirtualFile.delete(provider, getContext().getBlobStore(), blobPath);
     }
 
```

reproduced a test flake I have seen.