### PR TITLE
[JENKINS-41827] Running MinioIntegrationTest in a more realistic context

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.235.2</jenkins.version>
     <java.level>8</java.level>
-    <jenkins-test-harness.version>999999-SNAPSHOT</jenkins-test-harness.version> <!-- TODO https://github.com/jenkinsci/jenkins-test-harness/pull/280 -->
+    <jenkins-test-harness.version>1475.vfd967deeb478</jenkins-test-harness.version> <!-- TODO https://github.com/jenkinsci/jenkins-test-harness/pull/280 -->
     <useBeta>true</useBeta>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.235.2</jenkins.version>
     <java.level>8</java.level>
+    <jenkins-test-harness.version>999999-SNAPSHOT</jenkins-test-harness.version> <!-- TODO https://github.com/jenkinsci/jenkins-test-harness/pull/280 -->
     <useBeta>true</useBeta>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.235.2</jenkins.version>
     <java.level>8</java.level>
-    <jenkins-test-harness.version>1475.vfd967deeb478</jenkins-test-harness.version> <!-- TODO https://github.com/jenkinsci/jenkins-test-harness/pull/280 -->
+    <jenkins-test-harness.version>1484.v51078b2c2b34</jenkins-test-harness.version>
     <useBeta>true</useBeta>
   </properties>
 

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
@@ -39,6 +39,7 @@ import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.Bucket;
+import com.google.common.annotations.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
@@ -272,7 +273,8 @@ public class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
         return ret;
     }
 
-    AmazonS3ClientBuilder getAmazonS3ClientBuilderWithCredentials() throws IOException {
+    @VisibleForTesting
+    public AmazonS3ClientBuilder getAmazonS3ClientBuilderWithCredentials() throws IOException {
         return getAmazonS3ClientBuilderWithCredentials(getDisableSessionToken());
     }
 


### PR DESCRIPTION
Uses https://github.com/jenkinsci/jenkins-test-harness/pull/280.

If I deliberately break stuff

```diff
diff --git pom.xml pom.xml
index 3a9eb40..05d6355 100644
--- pom.xml
+++ pom.xml
@@ -271,20 +271,6 @@
     </dependencies>
   </dependencyManagement>
 
-  <build>
-      <plugins>
-          <plugin>
-            <groupId>org.jenkins-ci.tools</groupId>
-            <artifactId>maven-hpi-plugin</artifactId>
-            <configuration>
-              <!-- JENKINS-50520: since we need a custom version of Guava -->
-              <maskClasses>com.google.common.</maskClasses>
-            </configuration>
-          </plugin>
-
-      </plugins>
-  </build>
-
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
```

then I get the error I expect:

```
org.jvnet.hudson.test.RealJenkinsRule$ProxyException: 
java.lang.AssertionError: unexpected build status; build log was:
------
Legacy code started this job.  No cause information is available
Running as SYSTEM
Building remotely on slave0 in workspace …/workspace/test0
Archiving artifacts
ERROR: Step ‘Archive the artifacts’ aborted due to exception: 
java.lang.NoSuchMethodError: com.google.common.base.Preconditions.checkArgument(ZLjava/lang/String;Ljava/lang/Object;)V
	at com.google.common.reflect.TypeCapture.capture(TypeCapture.java:32)
	at com.google.common.reflect.TypeToken.<init>(TypeToken.java:117)
	at org.jclouds.rest.internal.BaseHttpApiMetadata$2.<init>(BaseHttpApiMetadata.java:54)
	at org.jclouds.rest.internal.BaseHttpApiMetadata.contextToken(BaseHttpApiMetadata.java:54)
	at org.jclouds.rest.internal.BaseHttpApiMetadata$Builder.init(BaseHttpApiMetadata.java:85)
	at org.jclouds.rest.internal.BaseHttpApiMetadata$Builder.<init>(BaseHttpApiMetadata.java:79)
	at org.jclouds.s3.S3ApiMetadata$Builder.<init>(S3ApiMetadata.java:98)
	at org.jclouds.aws.s3.AWSS3ApiMetadata$Builder.<init>(AWSS3ApiMetadata.java:58)
	at org.jclouds.aws.s3.AWSS3ApiMetadata.<init>(AWSS3ApiMetadata.java:43)
	at org.jclouds.aws.s3.AWSS3ProviderMetadata$Builder.<init>(AWSS3ProviderMetadata.java:113)
	at org.jclouds.aws.s3.AWSS3ProviderMetadata.builder(AWSS3ProviderMetadata.java:59)
	at io.jenkins.plugins.artifact_manager_jclouds.s3.S3BlobStore.getContext(S3BlobStore.java:113)
	at io.jenkins.plugins.artifact_manager_jclouds.s3.CustomBehaviorBlobStoreProvider.getContext(CustomBehaviorBlobStoreProvider.java:68)
	at io.jenkins.plugins.artifact_manager_jclouds.JCloudsArtifactManager.getContext(JCloudsArtifactManager.java:377)
	at io.jenkins.plugins.artifact_manager_jclouds.JCloudsArtifactManager.archive(JCloudsArtifactManager.java:125)
	at hudson.tasks.ArtifactArchiver.perform(ArtifactArchiver.java:252)
	at …
Finished: FAILURE

------

Expected: is <SUCCESS>
     but: was <FAILURE>
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:964)
	at org.jvnet.hudson.test.JenkinsRule.assertBuildStatus(JenkinsRule.java:1429)
	at org.jvnet.hudson.test.JenkinsRule.assertBuildStatus(JenkinsRule.java:1435)
	at org.jvnet.hudson.test.JenkinsRule.assertBuildStatusSuccess(JenkinsRule.java:1463)
	at org.jvnet.hudson.test.JenkinsRule.buildAndAssertSuccess(JenkinsRule.java:1490)
	at org.jenkinsci.plugins.workflow.ArtifactManagerTest.wrapInContainer(ArtifactManagerTest.java:131)
	at org.jenkinsci.plugins.workflow.ArtifactManagerTest.artifactArchiveAndDelete(ArtifactManagerTest.java:161)
	at io.jenkins.plugins.artifact_manager_jclouds.s3.MinioIntegrationTest._artifactArchiveAndDelete(MinioIntegrationTest.java:179)
	at io.jenkins.plugins.artifact_manager_jclouds.s3.MinioIntegrationTest$WithMinioServiceEndpoint.run(MinioIntegrationTest.java:144)
	at …
```