### PR TITLE
RealJenkinsRule updated, passing -Xmx100m

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.235.2</jenkins.version>
     <java.level>8</java.level>
-    <jenkins-test-harness.version>1484.v51078b2c2b34</jenkins-test-harness.version>
+    <jenkins-test-harness.version>1514.v9f0f59194dd4</jenkins-test-harness.version>
     <useBeta>true</useBeta>
   </properties>
 

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/MinioIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/MinioIntegrationTest.java
@@ -69,7 +69,7 @@ public class MinioIntegrationTest {
     private static S3BlobStore provider;
     
     @Rule
-    public RealJenkinsRule rr = new RealJenkinsRule();
+    public RealJenkinsRule rr = new RealJenkinsRule().javaOptions("-Xmx100m");
     
     @Rule
     public LoggerRule loggerRule = new LoggerRule().recordPackage(JCloudsArtifactManagerFactory.class, Level.FINE);


### PR DESCRIPTION
Picking up https://github.com/jenkinsci/jenkins-test-harness/pull/287 since I have seen `MinioIntegrationTest` be flaky in CI, perhaps due to JVM ergonomics issues. Also have an unreproduced report of a flaky error on Java 11

```
…	WARNING	j.u.ErrorLoggingScheduledThreadPoolExecutor#afterExecute: failure in task not wrapped in SafeTimerTask
groovy.lang.MissingMethodException: No signature of method: RealJenkinsRuleInit.invokeLater() is applicable for argument types: () values: []
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:58)
	at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.callCurrent(PogoMetaClassSite.java:81)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:52)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:154)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:158)
	at RealJenkinsRuleInit$_run_closure1$_closure2.doCall(RealJenkinsRuleInit.groovy:34)
	at RealJenkinsRuleInit$_run_closure1$_closure2.doCall(RealJenkinsRuleInit.groovy)
	at …
```

which could not happen after https://github.com/jenkinsci/jenkins-test-harness/pull/281.
