### PR TITLE
Tweaking RealJenkinsRule again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.235.2</jenkins.version>
     <java.level>8</java.level>
-    <jenkins-test-harness.version>1514.v9f0f59194dd4</jenkins-test-harness.version>
+    <jenkins-test-harness.version>1521.vaea1e973d086</jenkins-test-harness.version>
     <useBeta>true</useBeta>
   </properties>
 

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/MinioIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/MinioIntegrationTest.java
@@ -69,7 +69,7 @@ public class MinioIntegrationTest {
     private static S3BlobStore provider;
     
     @Rule
-    public RealJenkinsRule rr = new RealJenkinsRule().javaOptions("-Xmx100m");
+    public RealJenkinsRule rr = new RealJenkinsRule().javaOptions("-Xmx150m");
     
     @Rule
     public LoggerRule loggerRule = new LoggerRule().recordPackage(JCloudsArtifactManagerFactory.class, Level.FINE);


### PR DESCRIPTION
Amending #196 to pick up https://github.com/jenkinsci/jenkins-test-harness/pull/292 which I think should help address some OOMEs related to UC metadata parsing, by turning off the UC early enough in startup to matter.
