### PR TITLE
Update POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.17</version>
+    <version>4.18</version>
     <relativePath />
   </parent>
   <groupId>io.jenkins.plugins</groupId>
@@ -18,7 +18,6 @@
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.235.5</jenkins.version>
     <java.level>8</java.level>
-    <jenkins-test-harness.version>1521.vaea1e973d086</jenkins-test-harness.version>
     <useBeta>true</useBeta>
   </properties>
 


### PR DESCRIPTION
And remove `jenkins-test-harness.version` override so we go back to using the version from the parent, which is new enough.
