### PR TITLE
Update jclouds, picking up Guice from core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,7 +282,6 @@
               </dependencies>
             </requireSameVersions>
           </rules>
-
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,11 @@
       <artifactId>guava</artifactId>
       <version>30.1.1-jre</version>
     </dependency>
+    <dependency> <!-- also used along with guice-assistedinject in a newer version by jclouds -->
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <version>4.2.3</version>
+    </dependency>
   </dependencies>
   <dependencyManagement>
     <dependencies>
@@ -250,11 +255,6 @@
         <version>872.v03c18fa35487</version>
         <scope>import</scope>
         <type>pom</type>
-      </dependency>
-      <dependency> <!-- JENKINS-50520: picked up from jclouds; to match the Guice version in core -->
-        <groupId>com.google.inject.extensions</groupId>
-        <artifactId>guice-assistedinject</artifactId>
-        <version>4.0</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
@@ -280,8 +280,8 @@
             <groupId>org.jenkins-ci.tools</groupId>
             <artifactId>maven-hpi-plugin</artifactId>
             <configuration>
-              <!-- JENKINS-50520: since we need a custom version of Guava -->
-              <maskClasses>com.google.common.</maskClasses>
+              <!-- JENKINS-50520: since we need a custom version of Guava and Guice -->
+              <maskClasses>com.google.common. com.google.inject.</maskClasses>
             </configuration>
           </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -260,8 +260,33 @@
         <artifactId>error_prone_annotations</artifactId>
         <version>2.10.0</version>
       </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-assistedinject</artifactId>
+        <version>5.0.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <configuration>
+          <rules combine.children="append">
+            <requireSameVersions>
+              <dependencies>
+                <dependency>com.google.inject:guice</dependency>
+                <dependency>com.google.inject.extensions:guice-assistedinject</dependency>
+              </dependencies>
+            </requireSameVersions>
+          </rules>
+
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>org.apache.jclouds.provider</groupId>
       <artifactId>aws-s3</artifactId>
-      <version>2.3.0</version>
+      <version>2.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <revision>1.18</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.320</jenkins.version>
+    <jenkins.version>2.321</jenkins.version>
     <java.level>8</java.level>
     <useBeta>true</useBeta>
   </properties>
@@ -240,11 +240,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency> <!-- used along with guice-assistedinject in a newer version by jclouds -->
-      <groupId>com.google.inject</groupId>
-      <artifactId>guice</artifactId>
-      <version>4.2.3</version>
-    </dependency>
   </dependencies>
   <dependencyManagement>
     <dependencies>
@@ -267,20 +262,6 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
-  <build>
-      <plugins>
-          <plugin>
-            <groupId>org.jenkins-ci.tools</groupId>
-            <artifactId>maven-hpi-plugin</artifactId>
-            <configuration>
-              <!-- since we need a custom version of Guice -->
-              <maskClasses>com.google.inject.</maskClasses>
-            </configuration>
-          </plugin>
-
-      </plugins>
-  </build>
 
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>org.apache.jclouds.provider</groupId>
       <artifactId>aws-s3</artifactId>
-      <version>2.4.0</version>
+      <version>2.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.apache.jclouds.provider</groupId>
       <artifactId>aws-s3</artifactId>
-      <version>2.2.1</version>
+      <version>2.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/MockApiMetadata.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/MockApiMetadata.java
@@ -208,6 +208,7 @@ public final class MockApiMetadata extends BaseApiMetadata {
             return blob;
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public String putBlob(String containerName, Blob blob) throws IOException {
             {
@@ -220,6 +221,11 @@ public final class MockApiMetadata extends BaseApiMetadata {
             }
             blobsByContainer.get(containerName).put(blob.getMetadata().getName(), blob);
             return null;
+        }
+
+        @Override
+        public String putBlob(String containerName, Blob blob, BlobAccess ba) throws IOException {
+            return putBlob(containerName, blob);
         }
 
         @Override


### PR DESCRIPTION
Derived from #189. Follows up #244 to pick up https://github.com/jenkinsci/jenkins/pull/5858. https://github.com/jenkinsci/artifact-manager-s3-plugin/pull/226#issuecomment-972041078 tracks a further jclouds upgrade. Possibly solves [JENKINS-65824](https://issues.jenkins.io/browse/JENKINS-65824).