### PR TITLE
[JENKINS-66984] Pick up newer Guava from core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <revision>1.17</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.319-rc31639.bc827ae06789</jenkins.version> <!-- TODO https://github.com/jenkinsci/jenkins/pull/5707 -->
+    <jenkins.version>2.320</jenkins.version>
     <java.level>8</java.level>
     <useBeta>true</useBeta>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <revision>1.17</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.249.1</jenkins.version>
+    <jenkins.version>2.319-rc31639.bc827ae06789</jenkins.version> <!-- TODO https://github.com/jenkinsci/jenkins/pull/5707 -->
     <java.level>8</java.level>
     <useBeta>true</useBeta>
   </properties>
@@ -240,17 +240,12 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency> <!-- see maskClasses config -->
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>31.0.1-jre</version>
-    </dependency>
   </dependencies>
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.249.x</artifactId>
+        <artifactId>bom-2.249.x</artifactId> <!-- TODO weekly -->
         <version>966.v3857b7c82032</version>
         <scope>import</scope>
         <type>pom</type>
@@ -272,20 +267,6 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
-  <build>
-      <plugins>
-          <plugin>
-            <groupId>org.jenkins-ci.tools</groupId>
-            <artifactId>maven-hpi-plugin</artifactId>
-            <configuration>
-              <!-- JENKINS-50520: since we need a custom version of Guava -->
-              <maskClasses>com.google.common.</maskClasses>
-            </configuration>
-          </plugin>
-
-      </plugins>
-  </build>
 
   <repositories>
     <repository>

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/NetworkTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/NetworkTest.java
@@ -159,7 +159,7 @@ public class NetworkTest {
             r.assertLogNotContains("\tat hudson.tasks.ArtifactArchiver.perform", b);
             // Also from master:
             hangIn(BlobStoreProvider.HttpMethod.PUT, "p/2/artifacts/f");
-            p.setDefinition(new CpsFlowDefinition("node('master') {writeFile file: 'f', text: '.'; archiveArtifacts 'f'}", true));
+            p.setDefinition(new CpsFlowDefinition("node('" + r.jenkins.getSelfLabel().getName() + "') {writeFile file: 'f', text: '.'; archiveArtifacts 'f'}", true));
             b = r.buildAndAssertSuccess(p);
             r.assertLogContains("Retrying upload", b);
             r.assertLogNotContains("\tat hudson.tasks.ArtifactArchiver.perform", b);
@@ -181,7 +181,7 @@ public class NetworkTest {
         // Currently prints a stack trace of java.lang.InterruptedException; good enough.
         // Check the same from a timeout within the build, rather than a user abort, and also from master just for fun:
         hangIn(BlobStoreProvider.HttpMethod.PUT, "p/2/artifacts/f");
-        p.setDefinition(new CpsFlowDefinition("node('master') {writeFile file: 'f', text: '.'; timeout(time: 3, unit: 'SECONDS') {archiveArtifacts 'f'}}", true));
+        p.setDefinition(new CpsFlowDefinition("node('" + r.jenkins.getSelfLabel().getName() + "') {writeFile file: 'f', text: '.'; timeout(time: 3, unit: 'SECONDS') {archiveArtifacts 'f'}}", true));
         r.assertLogContains(new TimeoutStepExecution.ExceededTimeout().getShortDescription(), r.assertBuildStatus(Result.ABORTED, p.scheduleBuild2(0)));
     }
 
@@ -253,7 +253,7 @@ public class NetworkTest {
             r.assertLogContains("Retrying download", b);
             r.assertLogNotContains("\tat org.jenkinsci.plugins.workflow.flow.StashManager.unstash", b);
             hangIn(BlobStoreProvider.HttpMethod.GET, "p/2/stashes/f.tgz");
-            p.setDefinition(new CpsFlowDefinition("node('master') {writeFile file: 'f', text: '.'; stash 'f'; unstash 'f'}", true));
+            p.setDefinition(new CpsFlowDefinition("node('" + r.jenkins.getSelfLabel().getName() + "') {writeFile file: 'f', text: '.'; stash 'f'; unstash 'f'}", true));
             b = r.buildAndAssertSuccess(p);
             r.assertLogContains("Retrying download", b);
             r.assertLogNotContains("\tat org.jenkinsci.plugins.workflow.flow.StashManager.unstash", b);
@@ -273,7 +273,7 @@ public class NetworkTest {
         b.getExecutor().interrupt();
         r.assertBuildStatus(Result.ABORTED, r.waitForCompletion(b));
         hangIn(BlobStoreProvider.HttpMethod.GET, "p/2/stashes/f.tgz");
-        p.setDefinition(new CpsFlowDefinition("node('master') {writeFile file: 'f', text: '.'; stash 'f'; timeout(time: 3, unit: 'SECONDS') {unstash 'f'}}", true));
+        p.setDefinition(new CpsFlowDefinition("node('" + r.jenkins.getSelfLabel().getName() + "') {writeFile file: 'f', text: '.'; stash 'f'; timeout(time: 3, unit: 'SECONDS') {unstash 'f'}}", true));
         r.assertLogContains(new TimeoutStepExecution.ExceededTimeout().getShortDescription(), r.assertBuildStatus(Result.ABORTED, p.scheduleBuild2(0)));
     }
 

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/JCloudsArtifactManagerTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/JCloudsArtifactManagerTest.java
@@ -201,7 +201,7 @@ public class JCloudsArtifactManagerTest extends S3AbstractTest {
         wc.getPage(b, "artifact/3/4/");
         int httpCount = httpLogging.getRecords().size();
         System.err.println("total count: " + httpCount);
-        assertThat(httpCount, lessThanOrEqualTo(11));
+        assertThat(httpCount, lessThanOrEqualTo(13));
     }
 
     @Issue({"JENKINS-51390", "JCLOUDS-1200"})


### PR DESCRIPTION
[JENKINS-66984](https://issues.jenkins.io/browse/JENKINS-66984)

Downstream of https://github.com/jenkinsci/jenkins/pull/5707.

#215 and #226 might need to wait for a Guice upgrade.

See e.g. #140 for motivation.