### PR TITLE
Update jclouds to 2.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,11 +43,17 @@
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>aws-global-configuration</artifactId>
       <version>1.7</version>
+      <exclusions>
+        <exclusion>
+          <groupId>jakarta.xml.bind</groupId>
+          <artifactId>jakarta.xml.bind-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.jclouds.provider</groupId>
       <artifactId>aws-s3</artifactId>
-      <version>2.3.0</version>
+      <version>2.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -214,11 +220,6 @@
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-        <groupId>io.jenkins.plugins</groupId>
-        <artifactId>jaxb</artifactId>
-        <version>2.3.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>


### PR DESCRIPTION
Continuing #215. Contra https://github.com/jenkinsci/artifact-manager-s3-plugin/pull/226#issuecomment-972041078 it seems that we can do this now?

```
Bundling transitive dependency jaxb-impl-2.3.3.jar (via aws-s3)
Bundling transitive dependency jakarta.xml.bind-api-2.3.3.jar (via aws-s3)
Bundling transitive dependency javax.ws.rs-api-2.0.1.jar (via aws-s3)
```

:shrug:
