### PR TITLE
Use `guice-bom` from 2.324

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <revision>1.19</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.324-rc31790.510f226515b0</jenkins.version> <!-- TODO https://github.com/jenkinsci/jenkins/pull/6014 -->
+    <jenkins.version>2.324</jenkins.version>
     <java.level>8</java.level>
     <useBeta>true</useBeta>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <revision>1.19</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.321</jenkins.version>
+    <jenkins.version>2.324-rc31790.510f226515b0</jenkins.version> <!-- TODO https://github.com/jenkinsci/jenkins/pull/6014 -->
     <java.level>8</java.level>
     <useBeta>true</useBeta>
   </properties>
@@ -260,11 +260,6 @@
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
         <version>2.10.0</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.inject.extensions</groupId>
-        <artifactId>guice-assistedinject</artifactId>
-        <version>5.0.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Demonstrating that with the inclusion of `guice-bom` in jenkinsci/jenkins#6014 that plugins no longer need to declare an explicit version of Guice artifacts.