### PR TITLE
Removing `s3mock`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,22 +151,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.findify</groupId>
-      <artifactId>s3mock_2.12</artifactId>
-      <version>0.2.5</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.amazonaws</groupId>
-          <artifactId>aws-java-sdk</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.amazonaws</groupId>
-          <artifactId>aws-java-sdk-s3</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
#265 failed with internal dependency issues in S3Mock. Rather than work to maintain this dep, just removing it. Was only used in one test introduced in #62. As it turns out, #109 added another test of the same functionality https://github.com/jenkinsci/artifact-manager-s3-plugin/blob/d98e61689f41729e36a846079dca74299339d223/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/MinioIntegrationTest.java#L153-L162 which at least runs against an actual S3-compatible server with authentication and so is more convincing. Other interesting stuff to test would be `disableSessionToken`, use of acceleration, etc., which would require https://github.com/jenkinsci/artifact-manager-s3-plugin/blob/d98e61689f41729e36a846079dca74299339d223/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3AbstractTest.java#L63-L75
