### PR TITLE
Use JAXB plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.31</version>
+    <version>4.40</version>
     <relativePath />
   </parent>
   <groupId>io.jenkins.plugins</groupId>
@@ -15,8 +15,7 @@
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.324</jenkins.version>
-    <java.level>8</java.level>
+    <jenkins.version>2.332.1</jenkins.version>
     <useBeta>true</useBeta>
   </properties>
 
@@ -42,32 +41,28 @@
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>aws-global-configuration</artifactId>
       <version>1.7</version>
-      <exclusions>
-        <exclusion>
-          <groupId>jakarta.xml.bind</groupId>
-          <artifactId>jakarta.xml.bind-api</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>jaxb</artifactId>
+      <version>2.3.6-1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.jclouds.provider</groupId>
       <artifactId>aws-s3</artifactId>
       <version>2.5.0</version>
+      <exclusions>
+        <!-- Provided by jaxb plugin -->
+        <exclusion>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>aws-credentials</artifactId>
       <version>191.vcb_f183ce58b_9</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.checkerframework</groupId>
-          <artifactId>checker-qual</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -229,20 +224,22 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.249.x</artifactId> <!-- TODO weekly -->
-        <version>966.v3857b7c82032</version>
+        <artifactId>bom-2.332.x</artifactId>
+        <version>1362.v59f2f3db_80ee</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+      <!--
+        aws-java-sdk-minimal, which we depend on not directly but rather transitively via
+        aws-global-configuration, declares a dependency on an old version of jackson2-api that
+        causes upper bounds errors. Depending on a more recent version works around the issue.
+        When aws-global-configuration depends on a recent version of aws-java-sdk-minimal, this can
+        be deleted.
+      -->
       <dependency>
-        <groupId>joda-time</groupId>
-        <artifactId>joda-time</artifactId>
-        <version>2.10.14</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.errorprone</groupId>
-        <artifactId>error_prone_annotations</artifactId>
-        <version>2.13.1</version>
+        <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+        <artifactId>aws-java-sdk-minimal</artifactId>
+        <version>1.12.201-326.veb_6ce41104a_e</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Use the JAXB API and implementation from the JAXB plugin, relying on dynamic linking through a plugin-to-plugin dependency rather than embedding the JAR files unnecessarily in this plugin's `.jpi`. The only changes to the `.jpi` are the removal of the abovementionedJARs, which are present in the JAXB plugin. CC @jglick