### PR TITLE
Feat: Use tika to detect content type more accurately

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
       <version>2.3.6-1</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-core</artifactId>
+      <version>1.18</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.jclouds.provider</groupId>
       <artifactId>aws-s3</artifactId>
       <version>2.5.0</version>

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
@@ -61,7 +61,6 @@ import jenkins.MasterToSlaveFileCallable;
 import jenkins.model.ArtifactManager;
 import jenkins.util.VirtualFile;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.tika.Tika;
 import org.jclouds.blobstore.BlobStore;
 import org.jclouds.blobstore.BlobStoreContext;
 import org.jclouds.blobstore.BlobStores;
@@ -72,6 +71,8 @@ import org.jclouds.blobstore.options.ListContainerOptions;
 import org.jenkinsci.plugins.workflow.flow.StashManager;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import static io.jenkins.plugins.artifact_manager_jclouds.TikaUtil.detectByTika;
 
 /**
  * Jenkins artifact/stash implementation using any blob store supported by Apache jclouds.
@@ -160,7 +161,7 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
                     if (contentType == null) {
                         contentType = URLConnection.guessContentTypeFromName(theFile.getName());
                     }
-                    if (contentType == null){
+                    if (contentType == null) {
                         contentType = detectByTika(theFile);
                     }
                     contentTypes.put(relPath, contentType);
@@ -169,11 +170,6 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
                 }
             }
             return contentTypes;
-        }
-
-        static String detectByTika(File f) throws IOException {
-            Tika tika = new Tika();
-            return tika.detect(f);
         }
     }
 

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
@@ -61,6 +61,7 @@ import jenkins.MasterToSlaveFileCallable;
 import jenkins.model.ArtifactManager;
 import jenkins.util.VirtualFile;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.tika.Tika;
 import org.jclouds.blobstore.BlobStore;
 import org.jclouds.blobstore.BlobStoreContext;
 import org.jclouds.blobstore.BlobStores;
@@ -159,12 +160,20 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
                     if (contentType == null) {
                         contentType = URLConnection.guessContentTypeFromName(theFile.getName());
                     }
+                    if (contentType == null){
+                        contentType = detectByTika(theFile);
+                    }
                     contentTypes.put(relPath, contentType);
                 } catch (IOException e) {
                     Functions.printStackTrace(e, listener.error("Unable to determine content type for file: " + theFile));
                 }
             }
             return contentTypes;
+        }
+
+        static String detectByTika(File f) throws IOException {
+            Tika tika = new Tika();
+            return tika.detect(f);
         }
     }
 

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/TikaUtil.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/TikaUtil.java
@@ -1,0 +1,15 @@
+package io.jenkins.plugins.artifact_manager_jclouds;
+
+import org.apache.tika.Tika;
+
+import java.io.File;
+import java.io.IOException;
+
+public class TikaUtil {
+
+    private static Tika tika = new Tika();
+
+    static String detectByTika(File f) throws IOException {
+        return tika.detect(f);
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Use tika to detect content type more accurately.
I perform a manual test that the content type in s3 is expected.
<img width="767" alt="image" src="https://user-images.githubusercontent.com/1520380/180129381-5759b738-30c0-4743-893f-59c6ab1d4d11.png">



- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
