### PR TITLE
`JCloudsArtifactManager` fails to archive artifacts when their workspace path is not identical to their archive path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,12 @@
         <scope>test</scope>
     </dependency>
     <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-step-api</artifactId>
+        <classifier>tests</classifier>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.test</groupId>
       <artifactId>docker-fixtures</artifactId>
       <version>166.v912b_95083ffe</version>

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
@@ -132,10 +132,7 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
             String blobPath = getBlobPath(path);
             Blob blob = blobStore.blobBuilder(blobPath).build();
             blob.getMetadata().setContainer(provider.getContainer());
-            String contentType = contentTypes.get(entry.getValue());
-            if (contentType != null) {
-                blob.getMetadata().getContentMetadata().setContentType(contentType);
-            }
+            blob.getMetadata().getContentMetadata().setContentType(contentTypes.get(entry.getValue()));
             artifactUrls.put(entry.getValue(), provider.toExternalURL(blob, HttpMethod.PUT));
         }
 
@@ -170,6 +167,8 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
                     contentTypes.put(relPath, contentType);
                 } catch (IOException e) {
                     Functions.printStackTrace(e, listener.error("Unable to determine content type for file: " + theFile));
+                    // A content type must be specified; otherwise, the metadata signature will be computed from data that includes "Content-Type:", but no such HTTP header will be sent, and AWS will reject the request.
+                    contentTypes.put(relPath, "application/octet-stream");
                 }
             }
             return contentTypes;

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
@@ -132,7 +132,10 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
             String blobPath = getBlobPath(path);
             Blob blob = blobStore.blobBuilder(blobPath).build();
             blob.getMetadata().setContainer(provider.getContainer());
-            blob.getMetadata().getContentMetadata().setContentType(contentTypes.get(entry.getKey()));
+            String contentType = contentTypes.get(entry.getKey());
+            if (contentType != null) {
+                blob.getMetadata().getContentMetadata().setContentType(contentType);
+            }
             artifactUrls.put(entry.getValue(), provider.toExternalURL(blob, HttpMethod.PUT));
         }
 

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
@@ -132,7 +132,7 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
             String blobPath = getBlobPath(path);
             Blob blob = blobStore.blobBuilder(blobPath).build();
             blob.getMetadata().setContainer(provider.getContainer());
-            String contentType = contentTypes.get(entry.getKey());
+            String contentType = contentTypes.get(entry.getValue());
             if (contentType != null) {
                 blob.getMetadata().getContentMetadata().setContentType(contentType);
             }

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
@@ -121,7 +121,7 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
     public void archive(FilePath workspace, Launcher launcher, BuildListener listener, Map<String, String> artifacts)
             throws IOException, InterruptedException {
         LOGGER.log(Level.FINE, "Archiving from {0}: {1}", new Object[] { workspace, artifacts });
-        Map<String, String> contentTypes = workspace.act(new ContentTypeGuesser(new ArrayList<>(artifacts.keySet()), listener));
+        Map<String, String> contentTypes = workspace.act(new ContentTypeGuesser(new ArrayList<>(artifacts.values()), listener));
         LOGGER.fine(() -> "guessing content types: " + contentTypes);
         Map<String, URL> artifactUrls = new HashMap<>();
         BlobStore blobStore = getContext().getBlobStore();


### PR DESCRIPTION
I noticed a case where artifacts were not being stored for a build when using `withMaven` and `JCloudsArtifactManager`. There seem to be two related problems, and fixing either one of them should fix the issue.

I currently do not have AWS access and so am not able to test this PR, which is why it is a draft.

1. Content type detection currently uses the keys of `Map<String, String> artifacts` in `ArtifactManager.archive` when looking for the files in the workspace, however based on the [Javadoc](https://github.com/jenkinsci/jenkins/blob/5755957b3ab2f2826edea20660b2a82f7537f456/core/src/main/java/jenkins/model/ArtifactManager.java#L63) the keys are actually the archive paths and the workspace paths are the values. This does not matter for [`archiveArtifacts`](https://github.com/jenkinsci/jenkins/blob/5755957b3ab2f2826edea20660b2a82f7537f456/core/src/main/java/hudson/tasks/ArtifactArchiver.java#L323), but it does matter for [`withMaven`](https://github.com/jenkinsci/pipeline-maven-plugin/blob/b39f08d623384615e1a3bf3e987a7a55c8048d72/jenkins-plugin/src/main/java/org/jenkinsci/plugins/pipeline/maven/publishers/GeneratedArtifactsPublisher.java#L106). In my case, this led to a `FileNotFoundException` since the archive path was not a real file in the workspace. This error on its own is non-fatal, but it does log a warning for each artifact.
2. When the content type for an artifact cannot be detected, currently we set `content-type` to `null` in the content metadata. It seems that this data is signed on the client side and then verified by AWS and compared to the HTTP headers, but [the HTTP client being used does not send a `Content-Type` header when the value is null](https://github.com/jenkinsci/apache-httpcomponents-client-4-api-plugin/blob/4e7d9a7bae61f816f95f6fc1fb144e6ed40895f1/src/main/java/io/jenkins/plugins/httpclient/RobustHTTPClient.java#L252), leading to a mismatch and this error from AWS (reformatted slightly), which is fatal and the artifact is not archived:

```
hudson.AbortException: Failed to upload ... to ..., response: 400 Bad Request, body:
    <?xml version='1.0' encoding='UTF-8'?>
    <Error>
      <Code>MalformedSecurityHeader</Code>
      <Message>Your request has a malformed header.</Message>
      <ParameterName>content-type</ParameterName>
      <Details>Header was included in signedheaders, but not in the request.</Details>
    </Error>
    at io.jenkins.plugins.httpclient.RobustHTTPClient.lambda$connect$0(RobustHTTPClient.java:181)
    ... 4 more
    Suppressed: hudson.remoting.Channel$CallSiteStackTrace: Remote call to JNLP4-connect connection from 10.130.6.194/10.130.6.194:49124
        at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1784)
        at hudson.remoting.UserRequest$ExceptionResponse.retrieve(UserRequest.java:356)
        at hudson.remoting.Channel.call(Channel.java:1000)
        at hudson.FilePath.act(FilePath.java:1186)
        at hudson.FilePath.act(FilePath.java:1175)
        at io.jenkins.plugins.artifact_manager_jclouds.JCloudsArtifactManager.archive(JCloudsArtifactManager.java:139)
        at org.jenkinsci.plugins.pipeline.maven.publishers.GeneratedArtifactsPublisher.process(GeneratedArtifactsPublisher.java:129)
        at org.jenkinsci.plugins.pipeline.maven.MavenSpyLogProcessor.processMavenSpyLogs(MavenSpyLogProcessor.java:153)
        at org.jenkinsci.plugins.pipeline.maven.WithMavenStepExecution2$WithMavenStepExecutionCallBack.finished(WithMavenStepExecution2.java:1102)
        at org.jenkinsci.plugins.workflow.steps.GeneralNonBlockingStepExecution$TailCall.lambda$onSuccess$0(GeneralNonBlockingStepExecution.java:140)
        at org.jenkinsci.plugins.workflow.steps.GeneralNonBlockingStepExecution.lambda$run$0(GeneralNonBlockingStepExecution.java:77)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        ... 4 more
```

My PR proposes to just omit `content-type` from the blob metadata in this case, but I am not sure if this is allowed by AWS, so this may need to be reverted.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
