### PR TITLE
Skip test if using `AnonymousAWSCredentials`

### DIFF
--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3AbstractTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3AbstractTest.java
@@ -44,6 +44,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
 
 import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.AnonymousAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
 import io.jenkins.plugins.artifact_manager_jclouds.BlobStoreProvider;
@@ -67,7 +68,7 @@ public abstract class S3AbstractTest {
         try {
             AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard();
             assumeTrue(S3_BUCKET + " bucket does not exist", builder.build().doesBucketExistV2(S3_BUCKET));
-            assumeThat("can get credentials from environment", builder.getCredentials().getCredentials(), notNullValue());
+            assumeThat("can get credentials from environment", builder.getCredentials().getCredentials(), allOf(notNullValue(), not(isA(AnonymousAWSCredentials.class))));
         } catch (SdkClientException x) {
             x.printStackTrace();
             assumeNoException("failed to connect to S3 with current credentials", x);

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3AbstractTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3AbstractTest.java
@@ -68,6 +68,7 @@ public abstract class S3AbstractTest {
         try {
             AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard();
             assumeTrue(S3_BUCKET + " bucket does not exist", builder.build().doesBucketExistV2(S3_BUCKET));
+            builder.build().listObjects(S3_BUCKET);
             assumeThat("can get credentials from environment", builder.getCredentials().getCredentials(), allOf(notNullValue(), not(isA(AnonymousAWSCredentials.class))));
         } catch (SdkClientException x) {
             x.printStackTrace();


### PR DESCRIPTION
At some point apparently `AWSCredentialsProvider.getCredentials` stopped returning `null` and started returning an `AnonymousAWSCredentials` object, causing tests to fail later in `CredentialsAwsGlobalConfiguration.sessionCredentialsFromInstanceProfile`.