### PR TITLE
[JENKINS-71078] Better report lack of AWS credentials

### DIFF
--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStore.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStore.java
@@ -157,6 +157,9 @@ public class S3BlobStore extends BlobStoreProvider {
         
         if (getConfiguration().getDisableSessionToken()) {
             AmazonWebServicesCredentials awsCredentials = CredentialsAwsGlobalConfiguration.get().getCredentials();
+            if (awsCredentials == null) {
+                throw new IOException("No static AWS credentials found");
+            }
             accessKeyId = awsCredentials.getCredentials().getAWSAccessKeyId();
             secretKey = awsCredentials.getCredentials().getAWSSecretKey();
             sessionToken = "";


### PR DESCRIPTION
“Test 2” in [JENKINS-71078](https://issues.jenkins.io/browse/JENKINS-71078) looks like a misconfiguration: `disableSessionToken` means you must specify static credentials.