### PR TITLE
`MinioIntegrationTest` should assume Docker Linux specifically

### DIFF
--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/MinioIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/MinioIntegrationTest.java
@@ -37,6 +37,7 @@ import java.time.Duration;
 import java.util.logging.Level;
 import jenkins.model.ArtifactManagerFactory;
 import jenkins.model.Jenkins;
+import static org.hamcrest.Matchers.is;
 import org.jenkinsci.plugins.workflow.ArtifactManagerTest;
 import org.jenkinsci.test.acceptance.docker.DockerImage;
 import org.junit.AfterClass;
@@ -80,8 +81,9 @@ public class MinioIntegrationTest {
 
     @BeforeClass
     public static void setUpClass() throws Exception {
+        // Beyond just isDockerAvailable, verify the OS:
         try {
-            DockerClientFactory.instance().client();
+            Assume.assumeThat("expect to run Docker on Linux containers", DockerClientFactory.instance().client().infoCmd().exec().getOsType(), is("linux"));
         } catch (Exception x) {
             Assume.assumeNoException("does not look like Docker is available", x);
         }


### PR DESCRIPTION
Complementing https://github.com/jenkins-infra/pipeline-library/pull/658. Not touching https://github.com/jenkinsci/artifact-manager-s3-plugin/blob/12f03e8929826c17f76c885661c792265f6d824c/Jenkinsfile#L1-L4 unless I am told it is wrong/deprecated (and what the replacement should be).

https://github.com/jenkins-infra/helpdesk/issues/3548 not particularly relevant in this context—I am fine with the test running only on Linux.