### PR TITLE
Adapt to workflow-job-plugin#357

### DIFF
--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/NetworkTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/NetworkTest.java
@@ -341,8 +341,11 @@ public class NetworkTest {
         WorkflowJob p = r.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("node('remote') {writeFile file: 'f', text: '.'; stash 'stuff'}", true));
         MockApiMetadata.handleRemoveBlob("container", "p/1/stashes/stuff.tgz", () -> {throw new ContainerNotFoundException("container", "sorry about your stashes");});
-        r.buildAndAssertSuccess(p);
-        expectLogMessage("container not found: sorry about your stashes");
+        WorkflowRun b = r.buildAndAssertSuccess(p);
+        if (!JenkinsRule.getLog(b).contains("container not found: sorry about your stashes")) {
+            // TODO delete after https://github.com/jenkinsci/workflow-job-plugin/pull/357
+            expectLogMessage("container not found: sorry about your stashes");
+        }
     }
 
     // Interrupts probably never delivered during HTTP requests (maybe depends on servlet container?).


### PR DESCRIPTION
https://github.com/jenkinsci/workflow-job-plugin/pull/357#discussion_r1204538812 would break an assertion because the message is now sent to the build rather than system log (which we want).