### PR TITLE
[JENKINS-72441] Artifact Manager on S3 not compatible with GSON 2.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,14 @@
           </rules>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <configuration>
+          <!-- TODO JCLOUDS-1620 -->
+          <maskClasses>com.google.gson.</maskClasses>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Workaround for [JENKINS-72441](https://issues.jenkins.io/browse/JENKINS-72441) pending the release of the fix for [JCLOUDS-1620](https://issues.apache.org/jira/browse/JCLOUDS-1620) in https://github.com/apache/jclouds/pull/176.

### Testing done

Reproduced the problem by creating a Pipeline job that uploaded an artifact to S3. Could no longer reproduce the problem after this PR. Also verified in the Script Console that loading `com.google.gson.Gson` from the Artifact Manager on S3 plugin classloader loaded the class from the GSON API plugin's GSON JAR before this PR and from the Artifact Manager on S3 plugin's GSON JAR after this PR.