### PR TITLE
Rename configuration title to be more specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For more details check [AWS Credentials](#aws-credentials)
 
 * S3 Bucket Region: Region to use to generate the URLs to get/put artifacts, by default it is autodetected.
 
-After that you can configure the S3 Bucket settings on Manage Jenkins/Amazon Web Services Configuration on the section `Amazon S3 Bucket Access settings` in 
+After that you can configure the S3 Bucket settings on Manage Jenkins/Amazon Web Services Configuration on the section `Artifact Manager Amazon S3 Bucket` in 
 the same configuration page.
 
 * S3 Bucket Name: Name of the S3 Bucket to use to store artifacts.

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
@@ -262,7 +262,7 @@ public final class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
     @NonNull
     @Override
     public String getDisplayName() {
-        return "Amazon S3 Bucket Access settings";
+        return "Artifact Manager Amazon S3 Bucket";
     }
 
     @NonNull

--- a/src/main/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig/config.jelly
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
-    <f:section title="${%Amazon S3 Bucket Access settings}">
+    <f:section title="${%Artifact Manager Amazon S3 Bucket}">
         <f:entry title="${%S3 Bucket Name}" field="container">
             <f:textbox/>
         </f:entry>


### PR DESCRIPTION
While opening https://github.com/jenkinsci/jobcacher-plugin/issues/262 and wanted to implement  https://github.com/jenkinsci/jobcacher-plugin/issues/256 I found the title confusing and too generic.

It makes think that the configuration can be used for other plugin but it's only for Artifact Storage management.

Other plugin like `jobcacher` that upload caches to S3 endpoint have their own configuration and can benefit only (if they want to) of credentials from `aws-global-configuration-plugin`

### Testing done

![name_s3_manager](https://github.com/jenkinsci/artifact-manager-s3-plugin/assets/825750/29c98a01-213a-4145-81e1-d4a8b135831b)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
