### PR TITLE
Fix JENKINS-56740 - AWS CLI Option for artifacts over 5Gb with S3 Storage Class select option (STANDARD, STANDARD_IA).

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,7 +825,8 @@ Missing target/classes/index.jelly. Delete any <description> from pom.xml and cr
 # Changelog
 
 ## AWS CLI Patch
-- Use AWS CLI for files upload to avoid issues with big files upload.
+- Add option to use AWS CLI for big files upload to avoid issues with big files having over 5Gb.
+- Add option to set AWS S3 Storage Class STANDARD_IA instead of the default STANDARD.
 - Tests are disabled as not adapted for AWS CLI usage.
 
 ## 1.7 and newer

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <useBeta>true</useBeta>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
+<!--    <maven.test.skip>true</maven.test.skip>-->
   </properties>
 
   <name>Artifact Manager on S3 plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <jenkins.version>2.443</jenkins.version>
+    <patch.version>2.2</patch.version>
     <useBeta>true</useBeta>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
@@ -143,7 +143,8 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
                         "cp",
                         "--quiet",
                         "--no-guess-mime-type",
-                        entry.getValue(), remotePath};
+                        entry.getValue(), remotePath,
+                        "--storage-class", "STANDARD_IA"};
                 int cmdResult = launcher.launch(cmd, new String[0], null, listener.getLogger(), workspace).join();
                 if (cmdResult == 0) {
                     artifactUrls.put(entry.getValue(), remotePath);

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
@@ -95,6 +95,8 @@ public final class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
     
     private boolean useTransferAcceleration;
 
+    private boolean useAWSCLI;
+
     private boolean disableSessionToken;
     
     private String customEndpoint;
@@ -115,7 +117,7 @@ public final class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
         private transient S3BlobStoreConfig config;
 
         S3BlobStoreTester(String container, String prefix, boolean useHttp,
-            boolean useTransferAcceleration, boolean usePathStyleUrl,
+            boolean useTransferAcceleration, boolean useAWSCLI, boolean usePathStyleUrl,
             boolean disableSessionToken, String customEndpoint,
             String customSigningRegion) {
             config = new S3BlobStoreConfig();
@@ -125,6 +127,7 @@ public final class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
             config.setCustomSigningRegion(customSigningRegion);
             config.setUseHttp(useHttp);
             config.setUseTransferAcceleration(useTransferAcceleration);
+            config.setUseAWSCLI(useAWSCLI);
             config.setUsePathStyleUrl(usePathStyleUrl);
             config.setDisableSessionToken(disableSessionToken);
         }
@@ -211,6 +214,16 @@ public final class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
     @DataBoundSetter
     public void setUseTransferAcceleration(boolean useTransferAcceleration){
         this.useTransferAcceleration = useTransferAcceleration;
+        save();
+    }
+
+    public boolean getUseAWSCLI() {
+        return useAWSCLI;
+    }
+
+    @DataBoundSetter
+    public void setUseAWSCLI(boolean useAWSCLI){
+        this.useAWSCLI = useAWSCLI;
         save();
     }
 
@@ -404,6 +417,7 @@ public final class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
             @QueryParameter String prefix,
             @QueryParameter boolean useHttp,
             @QueryParameter boolean useTransferAcceleration,
+            @QueryParameter boolean useAWSCLI,
             @QueryParameter boolean usePathStyleUrl,
             @QueryParameter boolean disableSessionToken, 
             @QueryParameter String customEndpoint,
@@ -412,7 +426,7 @@ public final class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
         FormValidation ret = FormValidation.ok("success");
         
         S3BlobStore provider = new S3BlobStoreTester(container, prefix, 
-                useHttp, useTransferAcceleration,usePathStyleUrl,
+                useHttp, useTransferAcceleration,useAWSCLI,usePathStyleUrl,
                 disableSessionToken, customEndpoint, customSigningRegion);
         
         try {

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?jelly escape-by-default='true'?>
 <div>
-    A Jenkins plugin to keep artifacts and Pipeline stashes in Amazon S3.
+    A Jenkins plugin to keep artifacts and Pipeline stashes in Amazon S3 with AWS CLI option.
+    Use AWS CLI option for big artifacts (over 5Gb) upload to Amazon S3.
 </div>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -2,5 +2,7 @@
 <?jelly escape-by-default='true'?>
 <div>
     A Jenkins plugin to keep artifacts and Pipeline stashes in Amazon S3 with AWS CLI option.
-    Use AWS CLI option for big artifacts (over 5Gb) upload to Amazon S3 with STANDARD_IA S3 Storage Class.
+    Use AWS CLI (Command Line Interface) instead of the default AWS API for:
+    (i) big artifacts (over 5Gb) upload to Amazon S3;
+    (ii) option to support the STANDARD_IA S3 Storage Class instead of the default STANDARD.
 </div>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -2,5 +2,5 @@
 <?jelly escape-by-default='true'?>
 <div>
     A Jenkins plugin to keep artifacts and Pipeline stashes in Amazon S3 with AWS CLI option.
-    Use AWS CLI option for big artifacts (over 5Gb) upload to Amazon S3.
+    Use AWS CLI option for big artifacts (over 5Gb) upload to Amazon S3 with STANDARD_IA S3 Storage Class.
 </div>

--- a/src/main/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig/config.jelly
@@ -29,11 +29,14 @@
         <f:entry title="${%Use Transfer Acceleration}" field="useTransferAcceleration">
             <f:checkbox/>
         </f:entry>
+        <f:entry title="${%Use AWS CLI for files upload to S3}" field="useAWSCLI">
+            <f:checkbox/>
+        </f:entry>
         <f:entry title="${%Disable Session Token}" field="disableSessionToken">
             <f:checkbox/>
         </f:entry>
         <f:validateButton title="Validate S3 Bucket configuration" progress="Validate..." method="validateS3BucketConfig"
-                          with="container,prefix,useHttp,useTransferAcceleration,usePathStyleUrl,disableSessionToken,customEndpoint,customSigningRegion"/>
+                          with="container,prefix,useHttp,useTransferAcceleration,useAWSCLI,usePathStyleUrl,disableSessionToken,customEndpoint,customSigningRegion"/>
         <f:validateButton title="Create S3 Bucket from configuration" progress="Creating S3 Bucket..." method="createS3Bucket"
                           with="container,disableSessionToken"/>
     </f:section>

--- a/src/main/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig/config.jelly
@@ -29,14 +29,21 @@
         <f:entry title="${%Use Transfer Acceleration}" field="useTransferAcceleration">
             <f:checkbox/>
         </f:entry>
-        <f:entry title="${%Use AWS CLI for files upload to S3}" field="useAWSCLI">
-            <f:checkbox/>
-        </f:entry>
         <f:entry title="${%Disable Session Token}" field="disableSessionToken">
             <f:checkbox/>
         </f:entry>
+        <f:entry title="${%Use AWS CLI for files upload to S3}" field="useAWSCLI">
+            <f:checkbox/>
+        </f:entry>
+        <f:entry name="customStorageClass" title="S3 Storage Class" field="customStorageClass">
+            <select name="customStorageClass">
+                <option value="STANDARD" selected="${instance.customStorageClass.equals('STANDARD')?'true':null}">STANDARD</option>
+                <option value="STANDARD_IA"  selected="${instance.customStorageClass.equals('STANDARD_IA')?'true':null}"
+                >STANDARD_IA</option>
+            </select>
+        </f:entry>
         <f:validateButton title="Validate S3 Bucket configuration" progress="Validate..." method="validateS3BucketConfig"
-                          with="container,prefix,useHttp,useTransferAcceleration,useAWSCLI,usePathStyleUrl,disableSessionToken,customEndpoint,customSigningRegion"/>
+                          with="container,prefix,useHttp,useTransferAcceleration,useAWSCLI,customStorageClass,usePathStyleUrl,disableSessionToken,customEndpoint,customSigningRegion"/>
         <f:validateButton title="Create S3 Bucket from configuration" progress="Creating S3 Bucket..." method="createS3Bucket"
                           with="container,disableSessionToken"/>
     </f:section>

--- a/src/main/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig/help-customStorageClass.html
+++ b/src/main/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig/help-customStorageClass.html
@@ -1,0 +1,3 @@
+<div>This parameter allows to change the uploaded object
+ <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html">S3 Storage Class</a>.
+<br>This option works only when AWS CLI is enabled. Otherwise, only STANDARD Storage Class will be used.</div>

--- a/src/main/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig/help-useAWSCLI.html
+++ b/src/main/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig/help-useAWSCLI.html
@@ -1,0 +1,7 @@
+<div>This parameter switches the default AWS API mode to AWS CLI mode with use of
+    <a href="https://docs.aws.amazon.com/cli/latest/reference/s3/">AWS S3 Command Line Interface (CLI) file commands</a>
+    for artifact files upload to S3.
+<p>This option is a workaround for big files transfer API error for file bigger than 5Gb (MaxSizeAllowed=5368709120 bytes):</p>
+<pre>ERROR: Step ‘Archive the artifacts’ failed ..., response: 400 Bad Request,</pre>
+<pre> EntityTooLarge: Your proposed upload exceeds the maximum allowed size</pre>
+</div>

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/MockApiMetadataTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/MockApiMetadataTest.java
@@ -38,10 +38,11 @@ public class MockApiMetadataTest {
     public void smokes() throws Exception {
         BlobStoreContext bsc = ContextBuilder.newBuilder("mock").buildView(BlobStoreContext.class);
         BlobStore bs = bsc.getBlobStore();
-        bs.createContainerInLocation(null, "container");
+        String container = "container";
+        bs.createContainerInLocation(null, container);
         Blob blob = bs.blobBuilder("file.txt").payload("content").build();
-        bs.putBlob("container", blob);
-        assertEquals("file.txt", bs.list("container").stream().map(StorageMetadata::getName).collect(Collectors.joining(":")));
+        bs.putBlob(container, blob);
+        assertEquals("file.txt", bs.list(container).stream().map(StorageMetadata::getName).collect(Collectors.joining(":")));
     }
 
 }


### PR DESCRIPTION
Add AWS configuration options:
1. Add **AWS CLI Checkmark Option** as a fix or workaround for [JENKINS-56740](https://issues.jenkins.io/browse/JENKINS-56740) 
2. Add **Custom S3 Storage Class Select Option** (STANDARD_IA) for AWS CLI.
3.  Build tests are disabled (to be fixed).

With this change, the plugin artifacts upload method depends on the Jenkins setting at Jenkins > Setting > AWS.
Default AWS API method fails to upload artifacts bigger than 5GB.

### AWS CLI Option "Use AWS CLI for files upload to S3"
Workaround or fix for [JENKINS-56740](https://issues.jenkins.io/browse/JENKINS-56740).
AWS CLI Option is a workaround for big files transfer API error for file bigger than 5Gb. 
AWS CLI mode uses [AWS S3 Command Line Interface (CLI) commands](https://aws.amazon.com/cli/) for artifacts upload to AWS S3.

Default [AWS API](https://docs.aws.amazon.com/cli/latest/reference/s3/) fails to upload artifacts bigger than 5GB, MaxSizeAllowed is 5368709120 bytes (5Gb).
See [JENKINS-56740](https://issues.jenkins.io/browse/JENKINS-56740) - plugin fails to upload artifacts having size over 5Gb with errors like:
<pre>ERROR: Step ‘Archive the artifacts’ failed ..., response: 400 Bad Request,
EntityTooLarge: Your proposed upload exceeds the maximum allowed size</pre>


AWS option "Use AWS CLI for files upload to S3"  switches the default AWS API mode to AWS CLI mode.


### Add AWS S3 Storage Class selection option
**_Warning: Works for AWS CLI option only._**
Allows to select the [AWS S3 Storage Class](https://aws.amazon.com/s3/storage-classes/) for uploaded artifacts. 
The default S3 Storage Class is S3 Standard (STANDARD). 
This option allows so select S3 Storage Class **Standard IA** (STANDARD_IA). 
Useful for cost saving. 

### Testing done

Tested at local Jenkins test installation and on our  development Jenkins.
Add Jenkins job to test the plugin:

#### Test 1. PASSED. Failed(as expected) big file upload with default AWS API 
Fails upload gif files (6Gb) for default AWS API configuration with errors as expected by JENKINS-56740.

Jenkins job Artifact-Plugin-Test, build #47_AWS-API_STANDARD
Console Output:
<pre>
...
+ + ls -laR
tee -a build_47.log
.:
total 6291668
drwxr-xr-x  2 jenkins jenkins       4096 Feb 27 20:53 .
drwxr-xr-x 51 jenkins jenkins       4096 Feb  9 15:38 ..
-rw-r--r--  1 jenkins jenkins         77 Feb 27 20:53 build_47.log
-rw-r--r--  1 jenkins jenkins 6442450944 Feb 27 20:53 rand_20240227-205300.dat
New run name is '#47_AWS-API_STANDARD'
Archiving artifacts
AWS Storage Class selected option: STANDARD
AWS option selected:: Use AWS API...
ERROR: Step ‘Archive the artifacts’ failed: Failed to upload /var/lib/jenkins/workspace/Artifact-Plugin-Test/rand_20240227-205300.dat to https://XXX-build-artifacts.s3-accelerate.amazonaws.com/jobs/Artifact-Plugin-Test/47/artifacts/rand_20240227-205300.dat?…, response: 400 Bad Request, body: <?xml version="1.0" encoding="UTF-8"?>
<Error><Code>EntityTooLarge</Code><Message>Your proposed upload exceeds the maximum allowed size</Message><ProposedSize>6442450944</ProposedSize><MaxSizeAllowed>5368709120</MaxSizeAllowed><RequestId>97CMGW5283HFF06F</RequestId><HostId>friyoCjx5RJYxUiTjvFQIs2lAyShpRX7YrS9CWD425ANzDQk5sIwRqsCXgffXD3615sIW8vE02g=</HostId></Error>
Finished: FAILURE
</pre>
AWS S3 has no artifacts for this build.

#### Test 2. PASSED. big file upload with AWS CLI option checked and STANDARD Storage Class selected:
Jenkins job Artifact-Plugin-Test, build #48_AWS-CLI_STANDARD
Console Output:
<pre>
...
+ ls -laR
+ tee -a build_48.log
.:
total 6291636
drwxr-xr-x  2 jenkins jenkins       4096 Feb 27 20:56 .
drwxr-xr-x 51 jenkins jenkins       4096 Feb  9 15:38 ..
-rw-r--r--  1 jenkins jenkins         77 Feb 27 20:56 build_48.log
-rw-r--r--  1 jenkins jenkins 6442450944 Feb 27 20:57 rand_20240227-205642.dat
New run name is '#48_AWS-CLI_STANDARD'
Archiving artifacts
AWS Storage Class selected option: STANDARD
AWS option selected: Use AWS CLI...
Copy rand_20240227-205642.dat to s3://XXX-build-artifacts/jobs/Artifact-Plugin-Test/48/artifacts/rand_20240227-205642.dat
[Artifact-Plugin-Test] $ aws s3 cp --quiet --no-guess-mime-type rand_20240227-205642.dat s3://XXX-build-artifacts/jobs/Artifact-Plugin-Test/48/artifacts/rand_20240227-205642.dat --storage-class STANDARD
Copy build_48.log to s3://XXX-build-artifacts/jobs/Artifact-Plugin-Test/48/artifacts/build_48.log
[Artifact-Plugin-Test] $ aws s3 cp --quiet --no-guess-mime-type build_48.log s3://XXX-build-artifacts/jobs/Artifact-Plugin-Test/48/artifacts/build_48.log --storage-class STANDARD
Uploaded 2 artifact(s) to https://XXX-build-artifacts.s3.amazonaws.com/jobs/Artifact-Plugin-Test/48/artifacts/
Finished: SUCCESS
</pre>
AWS S3 has artifacts for this build with the Standard file objects Storage Class.

#### Test 3. PASSED. big file upload with AWS CLI option checked and STANDARD_IA Storage Class selected:
Jenkins job Artifact-Plugin-Test, build #49_AWS-CLI_STANDARD_IA
Console Output:
<pre>
...
+ + ls -laR
tee -a build_49.log
.:
total 6291656
drwxr-xr-x  2 jenkins jenkins       4096 Feb 27 21:05 .
drwxr-xr-x 51 jenkins jenkins       4096 Feb  9 15:38 ..
-rw-r--r--  1 jenkins jenkins         77 Feb 27 21:05 build_49.log
-rw-r--r--  1 jenkins jenkins 6442450944 Feb 27 21:05 rand_20240227-210508.dat
New run name is '#49_AWS-CLI_STANDARD_IA'
Archiving artifacts
AWS Storage Class selected option: STANDARD_IA
AWS option selected: Use AWS CLI...
Copy rand_20240227-210508.dat to s3://XXX-build-artifacts/jobs/Artifact-Plugin-Test/49/artifacts/rand_20240227-210508.dat
[Artifact-Plugin-Test] $ aws s3 cp --quiet --no-guess-mime-type rand_20240227-210508.dat s3://XXX-build-artifacts/jobs/Artifact-Plugin-Test/49/artifacts/rand_20240227-210508.dat --storage-class STANDARD_IA
Copy build_49.log to s3://XXX-build-artifacts/jobs/Artifact-Plugin-Test/49/artifacts/build_49.log
[Artifact-Plugin-Test] $ aws s3 cp --quiet --no-guess-mime-type build_49.log s3://XXX-build-artifacts/jobs/Artifact-Plugin-Test/49/artifacts/build_49.log --storage-class STANDARD_IA
Uploaded 2 artifact(s) to https://XXX-build-artifacts.s3.amazonaws.com/jobs/Artifact-Plugin-Test/49/artifacts/
Finished: SUCCESS
</pre>
AWS S3 has artifacts for this build with the Standard IA file objects Storage Class.


<!-- TODO:  Add config screenshots -->


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

