### PR TITLE
Exclude GSON from test classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,17 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>aws-credentials</artifactId>
       <version>191.vcb_f183ce58b_9</version>
+      <exclusions>
+        <!-- TODO JCLOUDS-1620 -->
+        <exclusion>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
@@ -137,6 +148,17 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-slaves</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <!-- TODO JCLOUDS-1620 -->
+        <exclusion>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Backports just enough of #450 to allow 2.440.x-based PCT to pass after https://github.com/jenkinsci/trilead-api-plugin/pull/131. #447 solved the issue for `RealJenkinsRule` but not `JenkinsRule`.