### PR TITLE
[JENKINS-73835] Adjust `NetworkTest.errorCleaningArtifacts` test to record more loggers for compatibility with newer cores

### DIFF
--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/NetworkTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/NetworkTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import jenkins.model.ArtifactManagerConfiguration;
+import jenkins.model.GlobalBuildDiscarderListener;
 import org.apache.http.ConnectionClosedException;
 import org.apache.http.HttpVersion;
 import org.apache.http.entity.StringEntity;
@@ -325,7 +326,7 @@ public class NetworkTest {
 
     @Test
     public void errorCleaningArtifacts() throws Exception {
-        loggerRule.record(WorkflowRun.class, Level.WARNING).record("jenkins.model.BackgroundGlobalBuildDiscarder", Level.WARNING).capture(10);
+        loggerRule.record(WorkflowRun.class, Level.WARNING).record("jenkins.model.BackgroundGlobalBuildDiscarder", Level.WARNING).record(GlobalBuildDiscarderListener.class, Level.WARNING).capture(10);
         WorkflowJob p = r.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("node('remote') {writeFile file: 'f', text: '.'; archiveArtifacts 'f'}", true));
         r.buildAndAssertSuccess(p);


### PR DESCRIPTION
See [https://issues.jenkins.io/browse/JENKINS-73835](https://issues.jenkins.io/browse/JENKINS-73835) and https://github.com/jenkinsci/jenkins/pull/9810. That PR changes which logger reports the log rotation error, causing `NetworkTest.errorCleaningArtifacts` to fail consistently against Jenkins 2.481+.

### Testing done

I bumped the parent POM to 5.1 and Jenkins version to 2.481 and verified that the test failed consistently without this patch, and passed consistently with it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
