### PR TITLE
[JENKINS-74810] Bom-2.440.x update from version  2779.v391653d9c5da_ to 3435.v238d66a_043fb_

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.440.x</artifactId>
-        <version>2779.v391653d9c5da_</version>
+        <version>3435.v238d66a_043fb_</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfigFipsEnabledTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfigFipsEnabledTest.java
@@ -1,25 +1,28 @@
 package io.jenkins.plugins.artifact_manager_jclouds.s3;
 
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.FlagRule;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.RealJenkinsRule;
 import hudson.util.FormValidation;
 import static org.junit.Assert.assertEquals;
-import jenkins.security.FIPS140;
+
+import java.io.IOException;
 
 
 public class S3BlobStoreConfigFipsEnabledTest {
 
-    @ClassRule
-    public static FlagRule<String> fipsFlag = FlagRule.systemProperty(FIPS140.class.getName() + ".COMPLIANCE", "true");
-
     @Rule
-    public JenkinsRule j = new JenkinsRule();
+    public RealJenkinsRule rule = new RealJenkinsRule().omitPlugins("eddsa-api").javaOptions("-Djenkins.security.FIPS140.COMPLIANCE=true");
+
 
     @Test
-    public void checkValidationUseHttpsWithFipsEnabled() {
+    public void checkUseHttpsWithFipsEnabledTest() throws Throwable {
+        rule.then(S3BlobStoreConfigFipsEnabledTest::checkUseHttpsWithFipsEnabled);
+    }
+
+
+    private static void checkUseHttpsWithFipsEnabled(JenkinsRule r) throws IOException {
         S3BlobStoreConfig descriptor = S3BlobStoreConfig.get();
         assertEquals(descriptor.doCheckUseHttp(true).kind , FormValidation.Kind.ERROR);
         assertEquals(descriptor.doCheckUseHttp(false).kind , FormValidation.Kind.OK);


### PR DESCRIPTION
Bumping BOM after change done in #560 
Raised by [https://github.com/jenkinsci/bom/pull/3932](https://github.com/jenkinsci/bom/pull/3932)

Additionally, excluded eddsa-api (won't allow starting up in FIPS mode) and updated tests to exclude it.

### Testing done

Testing done
Tests updated, no change in the logic itself



### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
