### PR TITLE
Upgrade jclouds from 2.5.0 to 2.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,9 @@
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.443</jenkins.version>
+    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+    <jenkins.baseline>2.452</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <useBeta>true</useBeta>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
@@ -45,6 +47,10 @@
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
+      <artifactId>gson-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
       <artifactId>jaxb</artifactId>
     </dependency>
     <dependency>
@@ -65,8 +71,13 @@
     <dependency>
       <groupId>org.apache.jclouds.provider</groupId>
       <artifactId>aws-s3</artifactId>
-      <version>2.5.0</version>
+      <version>2.6.0</version>
       <exclusions>
+        <!-- Provided by gson-api plugin -->
+        <exclusion>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+        </exclusion>
         <!-- Provided by jaxb plugin -->
         <exclusion>
           <groupId>com.sun.xml.bind</groupId>
@@ -82,11 +93,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>aws-credentials</artifactId>
       <exclusions>
-        <!-- TODO JCLOUDS-1620 -->
-        <exclusion>
-          <groupId>com.google.code.gson</groupId>
-          <artifactId>gson</artifactId>
-        </exclusion>
         <exclusion>
           <groupId>com.google.errorprone</groupId>
           <artifactId>error_prone_annotations</artifactId>
@@ -154,11 +160,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-slaves</artifactId>
       <exclusions>
-        <!-- TODO JCLOUDS-1620 -->
-        <exclusion>
-          <groupId>com.google.code.gson</groupId>
-          <artifactId>gson</artifactId>
-        </exclusion>
         <exclusion>
           <groupId>com.google.errorprone</groupId>
           <artifactId>error_prone_annotations</artifactId>
@@ -200,12 +201,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.code.gson</groupId>
-          <artifactId>gson</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -265,24 +260,22 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.440.x</artifactId>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
         <version>3435.v238d66a_043fb_</version>
         <scope>import</scope>
         <type>pom</type>
+      </dependency>
+      <!-- TODO remove when core has upgraded to 7.0.0 or newer -->
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-assistedinject</artifactId>
+        <version>6.0.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jenkins-ci.tools</groupId>
-        <artifactId>maven-hpi-plugin</artifactId>
-        <configuration>
-          <!-- TODO JCLOUDS-1620 -->
-          <maskClasses>com.google.gson.</maskClasses>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
@@ -296,6 +289,22 @@
             </requireSameVersions>
           </rules>
         </configuration>
+        <!-- TODO remove when core has upgraded to 7.0.0 or newer -->
+        <executions>
+          <execution>
+            <id>display-info</id>
+            <configuration>
+              <rules>
+                <requireUpperBoundDeps>
+                  <excludes combine.children="append">
+                    <exclude>com.google.inject:guice</exclude>
+                    <exclude>com.google.inject.extensions:guice-assistedinject</exclude>
+                  </excludes>
+                </requireUpperBoundDeps>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/MockApiMetadata.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/MockApiMetadata.java
@@ -191,7 +191,7 @@ public final class MockApiMetadata extends BaseApiMetadata {
         }
 
         @Override
-        public Iterable<String> getBlobKeysInsideContainer(String container, String prefix) throws IOException {
+        public Iterable<String> getBlobKeysInsideContainer(String container, String prefix, String delimiter) throws IOException {
             GetBlobKeysInsideContainerHandler handler = getBlobKeysInsideContainerHandlers.remove(container);
             if (handler != null) {
                 handler.run();


### PR DESCRIPTION
Reverting #447, since 2.6.0 contains the fix for [JCLOUDS-1620](https://issues.apache.org/jira/browse/JCLOUDS-1620).

jclouds 2.6.0 requires Guice 7.0.0, which is above the version delivered by core (6.0.0), but so far I have found no issue ignoring the upper bounds error and continuing to deliver Guice 6.0.0. Guice 6.0.0 supports both `javax` and `jakarta` imports, while 7.0.0 drops support for `javax`, so 6.0.0 makes more sense for Jenkins. Unfortunately this required adding a few temporary workarounds to the POM file.

### Testing done

`mvn clean verify`, including `MinioIntegrationTest`

I would appreciate if someone could do a manual test run with an AWS account, since I believe CI unfortunately is not enough.