### PR TITLE
Fixing `JCloudsVirtualFileTest.testAmpersand` for SSO

### DIFF
--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/JCloudsVirtualFileTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/JCloudsVirtualFileTest.java
@@ -53,7 +53,6 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.LoggerRule;
 
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import java.net.ProtocolException;
@@ -287,7 +286,7 @@ public class JCloudsVirtualFileTest extends S3AbstractTest {
         try {
             putBlob(blobStore.blobBuilder(key).payload("test").build());
 
-            final AmazonS3 s3 = AmazonS3ClientBuilder.defaultClient();
+            final AmazonS3 s3 = S3BlobStoreConfig.clientBuilder.get().build();
             ListObjectsV2Result result = s3.listObjectsV2(getContainer(), key);
             List<S3ObjectSummary> objects = result.getObjectSummaries();
             assertThat(objects, not(empty()));


### PR DESCRIPTION
Checking for regression from #567, I ran `mvn clean verify` locally after `aws sso login` and got a 403 failure in this test enabled since #78. I guess I must have forgotten to try a full build in #351, and in CI the SSO code is unused.