### PR TITLE
Simplifying `.github`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
-  reviewers:
-  - jglick
   ignore:
   - dependency-name: com.google.inject.extensions:guice-assistedinject
 - package-ecosystem: github-actions

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,1 +1,0 @@
-_extends: .github


### PR DESCRIPTION
https://github.com/jenkinsci/artifact-manager-s3-plugin/pull/620#issuecomment-2871419035 and also `release-drafter.yml` is unnecessary