### PR TITLE
Enforce region for aws sdk calls

### DIFF
--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStore.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStore.java
@@ -97,7 +97,7 @@ public class S3BlobStore extends BlobStoreProvider {
     }
 
     public String getRegion() {
-        return CredentialsAwsGlobalConfiguration.get().getRegion();
+        return getConfiguration().getRegion().id();
     }
 
     public S3BlobStoreConfig getConfiguration(){
@@ -219,6 +219,7 @@ public class S3BlobStore extends BlobStoreProvider {
         try (S3Client s3Client = getConfiguration().getAmazonS3ClientBuilderWithCredentials().build()) {
             S3Presigner.Builder presignerBuilder = S3Presigner.builder()
                     .fipsEnabled(FIPS140.useCompliantAlgorithms())
+                    .region(getConfiguration().getRegion())
                     .credentialsProvider(CredentialsAwsGlobalConfiguration.get().getCredentials())
                     .s3Client(s3Client);
             if (StringUtils.isNotBlank(customEndpoint)) {
@@ -227,7 +228,7 @@ public class S3BlobStore extends BlobStoreProvider {
 
             String customRegion = getConfiguration().getCustomSigningRegion();
             if(StringUtils.isBlank(customRegion)) {
-                customRegion = CredentialsAwsGlobalConfiguration.get().getRegion();
+                customRegion = getConfiguration().getRegion().id();
             }
             if(StringUtils.isNotBlank(customRegion)) {
                 presignerBuilder.region(Region.of(customRegion));

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
@@ -318,7 +318,7 @@ public final class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
 
     public Region getRegion() {
         String regionStr = CredentialsAwsGlobalConfiguration.get().getRegion();
-        if (StringUtils.isBlank(regionStr)) {
+        if (regionStr == null) {
             try {
                 return new DefaultAwsRegionProviderChain().getRegion();
             } catch (SdkClientException e) {

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
@@ -323,7 +323,7 @@ public final class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
                 return new DefaultAwsRegionProviderChain().getRegion();
             } catch (SdkClientException e) {
                 // need to revert to a default one.
-                LOGGER.warning("There is no region configured for this S3 bucket and aws sdk couldn't discover one so using default:" + Region.US_EAST_1);
+                LOGGER.warning("There is no region configured for this S3 bucket and aws sdk couldn't discover one so using default: " + Region.US_EAST_1);
                 return Region.US_EAST_1;
             }
         }

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
@@ -289,13 +289,15 @@ public final class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
         if (StringUtils.isNotBlank(getResolvedCustomEndpoint())) {
             String resolvedCustomSigningRegion = customSigningRegion;
             if (StringUtils.isBlank(resolvedCustomSigningRegion)) {
-                resolvedCustomSigningRegion = "us-east-1";
+                // we must revert to a region if no custom defined
+                resolvedCustomSigningRegion = getRegion().id();
             }
             ret = ret.endpointOverride(new URI(getResolvedCustomEndpoint())).region(Region.of(resolvedCustomSigningRegion));
-        } else if (StringUtils.isNotBlank(CredentialsAwsGlobalConfiguration.get().getRegion())) {
-            ret = ret.region(Region.of(CredentialsAwsGlobalConfiguration.get().getRegion()));
         } else {
-            ret = ret.useArnRegion(true);
+            // not really sure of why this was used.. this should have a dedicated parameter
+            //ret = ret.useArnRegion(true);
+            // use same defaull algorithm as signer 
+            ret = ret.region(getRegion());
         }
         ret = ret.accelerate(useTransferAcceleration);
 

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
@@ -296,7 +296,7 @@ public final class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
         } else {
             // not really sure of why this was used.. this should have a dedicated parameter
             //ret = ret.useArnRegion(true);
-            // use same defaull algorithm as signer 
+            // use same default algorithm as signer
             ret = ret.region(getRegion());
         }
         ret = ret.accelerate(useTransferAcceleration);

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
@@ -335,7 +335,6 @@ public final class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
         if (disableSessionToken) {
             builder = builder.credentialsProvider(CredentialsAwsGlobalConfiguration.get().getCredentials());
         } else {
-
             AwsSessionCredentials awsSessionCredentials = CredentialsAwsGlobalConfiguration.get()
                     .sessionCredentials(getRegion().id(), CredentialsAwsGlobalConfiguration.get().getCredentialsId());
             if(awsSessionCredentials != null ) {

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/JCloudsVirtualFileTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/JCloudsVirtualFileTest.java
@@ -28,7 +28,6 @@ import io.jenkins.plugins.artifact_manager_jclouds.JCloudsVirtualFile;
 import io.jenkins.plugins.aws.global_configuration.CredentialsAwsGlobalConfiguration;
 import static org.hamcrest.Matchers.*;
 import static org.jclouds.blobstore.options.ListContainerOptions.Builder.*;
-import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -56,7 +55,14 @@ import org.jvnet.hudson.test.LoggerRule;
 import java.net.ProtocolException;
 
 import jenkins.util.VirtualFile;
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.jclouds.http.HttpResponseException;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
@@ -248,7 +254,7 @@ public class JCloudsVirtualFileTest extends S3AbstractTest {
         });
         // Default list page size for S3 is 1000 blobs; we have 1010 plus the two created for all tests, so should hit a second page.
         assertThat(subdir.list("sprawling/**/k3", null, true), iterableWithSize(100));
-        assertEquals("calls GetBucketLocation then ListBucket, advance to …/sprawling/i9/j8/k8, ListBucket again", 3, httpLogging.getRecords().size());
+        assertThat("calls GetBucketLocation (perhaps) then ListBucket, advance to …/sprawling/i9/j8/k8, ListBucket again", httpLogging.getRecords().size(), lessThanOrEqualTo(3));
     }
 
     @Test


### PR DESCRIPTION
Using ec-2 with instance profile credentials. 
Having this stacktrace 
```

software.amazon.awssdk.core.exception.SdkClientException: Unable to load region from any of the providers in the chain software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain@a16c0c8: [software.amazon.awssdk.regions.providers.SystemSettingsRegionProvider@3a65b6b2: Unable to load region from system settings. Region must be specified either via environment variable (AWS_REGION) or  system property (aws.region)., software.amazon.awssdk.regions.providers.AwsProfileRegionProvider@10fa4669: No region provided in profile: default, software.amazon.awssdk.regions.providers.InstanceProfileRegionProvider@2eeef836: Unable to contact EC2 metadata service.]
	at PluginClassLoader for aws-java-sdk2-core//software.amazon.awssdk.core.exception.SdkClientException$BuilderImpl.build(SdkClientException.java:130)
	at PluginClassLoader for aws-java-sdk2-core//software.amazon.awssdk.regions.providers.AwsRegionProviderChain.getRegion(AwsRegionProviderChain.java:70)
	at PluginClassLoader for aws-java-sdk2-core//software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder.resolveRegion(AwsDefaultClientBuilder.java:374)
	at PluginClassLoader for aws-java-sdk2-core//software.amazon.awssdk.utils.AttributeMap$DerivedValue.primeCache(AttributeMap.java:604)
	at PluginClassLoader for aws-java-sdk2-core//software.amazon.awssdk.utils.AttributeMap$DerivedValue.get(AttributeMap.java:593)
	at PluginClassLoader for aws-java-sdk2-core//software.amazon.awssdk.utils.AttributeMap$Builder.resolveValue(AttributeMap.java:400)
	at PluginClassLoader for aws-java-sdk2-core//software.amazon.awssdk.utils.AttributeMap$Builder.internalGet(AttributeMap.java:389)
	at PluginClassLoader for aws-java-sdk2-core//software.amazon.awssdk.utils.AttributeMap$Builder.access$1300(AttributeMap.java:201)
	at PluginClassLoader for aws-java-sdk2-core//software.amazon.awssdk.utils.AttributeMap$Builder$1.get(AttributeMap.java:403)
	at PluginClassLoader for aws-java-sdk2-s3//software.amazon.awssdk.services.s3.DefaultS3BaseClientBuilder.lambda$finalizeServiceConfiguration$2(DefaultS3BaseClientBuilder.java:219)
	at PluginClassLoader for aws-java-sdk2-core//software.amazon.awssdk.utils.AttributeMap$DerivedValue.primeCache(AttributeMap.java:604)
	at PluginClassLoader for aws-java-sdk2-core//software.amazon.awssdk.utils.AttributeMap$DerivedValue.get(AttributeMap.java:593)
	at PluginClassLoader for aws-java-sdk2-core//software.amazon.awssdk.utils.AttributeMap$Builder.resolveValue(AttributeMap.java:400)
	at PluginClassLoader for aws-java-sdk2-core//software.amazon.awssdk.utils.AttributeMap$Builder.internalComputeIfAbsent(AttributeMap.java:331)
	at PluginClassLoader for aws-java-sdk2-core//software.amazon.awssdk.utils.AttributeMap$Builder.putLazyIfAbsent(AttributeMap.java:275)
	at PluginClassLoader for aws-java-sdk2-core//software.amazon.awssdk.core.client.config.SdkClientConfiguration$Builder.lazyOptionIfAbsent(SdkClientConfiguration.java:182)
	at PluginClassLoader for aws-java-sdk2-core//software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder.finalizeAwsConfiguration(AwsDefaultClientBuilder.java:190)
	at PluginClassLoader for aws-java-sdk2-core//software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder.finalizeChildConfiguration(AwsDefaultClientBuilder.java:172)
	at PluginClassLoader for aws-java-sdk2-core//software.amazon.awssdk.core.client.builder.SdkDefaultClientBuilder.syncClientConfiguration(SdkDefaultClientBuilder.java:202)
	at PluginClassLoader for aws-java-sdk2-s3//software.amazon.awssdk.services.s3.DefaultS3ClientBuilder.buildClient(DefaultS3ClientBuilder.java:37)
	at PluginClassLoader for aws-java-sdk2-s3//software.amazon.awssdk.services.s3.DefaultS3ClientBuilder.buildClient(DefaultS3ClientBuilder.java:26)
	at PluginClassLoader for aws-java-sdk2-core//software.amazon.awssdk.core.client.builder.SdkDefaultClientBuilder.build(SdkDefaultClientBuilder.java:169)
	at PluginClassLoader for artifact-manager-s3//io.jenkins.plugins.artifact_manager_jclouds.s3.S3BlobStore.toExternalURL(S3BlobStore.java:219)
	at PluginClassLoader for artifact-manager-s3//io.jenkins.plugins.artifact_manager_jclouds.JCloudsArtifactManager.archive(JCloudsArtifactManager.java:136)
	at hudson.tasks.ArtifactArchiver.perform(ArtifactArchiver.java:257)

```

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
