### PR TITLE
Update dependencies, use `OutboundAgent` for tests

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.8</version>
+    <version>1.10</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sso</artifactId>
       <!-- Not apparently packaged as a plugin, but anyway used only for developer testing: -->
-      <version>2.31.26</version>
+      <version>2.31.63</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -300,13 +300,13 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-api</artifactId>
-        <version>999999-SNAPSHOT</version>
+        <version>1378.v9b_957b_52b_c74</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-api</artifactId>
         <classifier>tests</classifier>
-        <version>999999-SNAPSHOT</version>
+        <version>1378.v9b_957b_52b_c74</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.17</version>
+    <version>5.18</version>
     <relativePath />
   </parent>
   <groupId>io.jenkins.plugins</groupId>
@@ -16,9 +16,8 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
-    <useBeta>true</useBeta>
+    <jenkins.baseline>2.504</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
   </properties>
@@ -130,36 +129,24 @@
         <artifactId>structs</artifactId>
     </dependency>
     <dependency>
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-api</artifactId>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-api</artifactId>
+      <!-- TODO: remove -->
+      <version>1377.vf606866f592b_</version>
     </dependency>
     <dependency>
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-api</artifactId>
-        <classifier>tests</classifier>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-step-api</artifactId>
-        <classifier>tests</classifier>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.test</groupId>
-      <artifactId>docker-fixtures</artifactId>
-      <version>200.v22a_e8766731c</version>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-api</artifactId>
+      <!-- TODO: remove -->
+      <version>1377.vf606866f592b_</version>
+      <classifier>tests</classifier>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-io</groupId> <!-- take version from Jenkins Core -->
-          <artifactId>commons-io</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -278,7 +265,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4710.v016f0a_07e34d</version>
+        <version>5015.vb_52d36583443</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -131,14 +131,10 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-api</artifactId>
-      <!-- TODO: remove -->
-      <version>1377.vf606866f592b_</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-api</artifactId>
-      <!-- TODO: remove -->
-      <version>1377.vf606866f592b_</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -157,6 +153,12 @@
           <artifactId>error_prone_annotations</artifactId>
         </exclusion>
       </exclusions>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>ssh-slaves</artifactId>
+      <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -281,6 +283,30 @@
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-assistedinject</artifactId>
         <version>6.0.0</version>
+      </dependency>
+      <!-- TODO https://github.com/jenkinsci/ssh-agents-plugin/pull/607 -->
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>ssh-slaves</artifactId>
+        <version>3.1069.v30991b_9a_4f68</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>ssh-slaves</artifactId>
+        <classifier>tests</classifier>
+        <version>3.1069.v30991b_9a_4f68</version>
+      </dependency>
+      <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/416 -->
+      <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-api</artifactId>
+        <version>999999-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-api</artifactId>
+        <classifier>tests</classifier>
+        <version>999999-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -103,10 +103,8 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>sso</artifactId>
-      <!-- Not apparently packaged as a plugin, but anyway used only for developer testing: -->
-      <version>2.31.63</version>
+      <groupId>io.jenkins.plugins.aws-java-sdk2</groupId>
+      <artifactId>aws-java-sdk2-sso</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -282,29 +282,28 @@
         <artifactId>guice-assistedinject</artifactId>
         <version>6.0.0</version>
       </dependency>
-      <!-- TODO https://github.com/jenkinsci/ssh-agents-plugin/pull/607 -->
+      <!-- TODO until in BOM -->
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>ssh-slaves</artifactId>
-        <version>3.1069.v30991b_9a_4f68</version>
+        <version>3.1071.v0d059c7b_c555</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>ssh-slaves</artifactId>
         <classifier>tests</classifier>
-        <version>3.1069.v30991b_9a_4f68</version>
+        <version>3.1071.v0d059c7b_c555</version>
       </dependency>
-      <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/416 -->
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-api</artifactId>
-        <version>1378.v9b_957b_52b_c74</version>
+        <version>1380.ve03e7a_63d139</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-api</artifactId>
         <classifier>tests</classifier>
-        <version>1378.v9b_957b_52b_c74</version>
+        <version>1380.ve03e7a_63d139</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/MockBlobStoreTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/MockBlobStoreTest.java
@@ -25,11 +25,13 @@
 package io.jenkins.plugins.artifact_manager_jclouds;
 
 import org.jenkinsci.plugins.workflow.ArtifactManagerTest;
+import static org.junit.Assume.assumeFalse;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.testcontainers.DockerClientFactory;
 
 public class MockBlobStoreTest {
 
@@ -41,6 +43,7 @@ public class MockBlobStoreTest {
 
     @Test
     public void smokes() throws Exception {
+        assumeFalse("Does not work when Dockerized since the mock server is inaccessible from the container", DockerClientFactory.instance().isDockerAvailable());
         ArtifactManagerTest.artifactArchiveAndDelete(j, new JCloudsArtifactManagerFactory(new MockBlobStore()), false);
         ArtifactManagerTest.artifactStashAndDelete(j, new JCloudsArtifactManagerFactory(new MockBlobStore()), false);
     }

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/MockBlobStoreTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/MockBlobStoreTest.java
@@ -41,8 +41,8 @@ public class MockBlobStoreTest {
 
     @Test
     public void smokes() throws Exception {
-        ArtifactManagerTest.artifactArchiveAndDelete(j, new JCloudsArtifactManagerFactory(new MockBlobStore()), false, null);
-        ArtifactManagerTest.artifactStashAndDelete(j, new JCloudsArtifactManagerFactory(new MockBlobStore()), false, null);
+        ArtifactManagerTest.artifactArchiveAndDelete(j, new JCloudsArtifactManagerFactory(new MockBlobStore()), false);
+        ArtifactManagerTest.artifactStashAndDelete(j, new JCloudsArtifactManagerFactory(new MockBlobStore()), false);
     }
 
 }

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/AbstractIntegrationTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/AbstractIntegrationTest.java
@@ -29,7 +29,7 @@ public abstract class AbstractIntegrationTest {
     protected static final String CONTAINER_PREFIX = "ci/";
 
     @BeforeClass
-    public static void assumeDocker() throws Exception {
+    public static void assumeDocker() {
         // Beyond just isDockerAvailable, verify the OS:
         try {
             Assume.assumeThat("expect to run Docker on Linux containers", DockerClientFactory.instance().client().infoCmd().exec().getOsType(), is("linux"));
@@ -54,7 +54,7 @@ public abstract class AbstractIntegrationTest {
 
     protected static void _artifactArchiveAndDelete(JenkinsRule jenkinsRule) throws Throwable {
         createBucketWithAwsClient("artifact-archive-and-delete");
-        ArtifactManagerTest.artifactArchiveAndDelete(jenkinsRule, getArtifactManagerFactory(true, null), true, null);
+        ArtifactManagerTest.artifactArchiveAndDelete(jenkinsRule, getArtifactManagerFactory(true, null), true);
     }
 
     protected static void createBucketWithAwsClient(String bucketName) throws IOException {
@@ -66,12 +66,12 @@ public abstract class AbstractIntegrationTest {
     protected static void _artifactArchive(JenkinsRule jenkinsRule) throws Throwable {
         createBucketWithAwsClient("artifact-archive");
         assertThat(client().headBucket(HeadBucketRequest.builder().bucket("artifact-archive").build()).sdkHttpResponse().isSuccessful(), is(true));
-        ArtifactManagerTest.artifactArchive(jenkinsRule, getArtifactManagerFactory(null, null), true, null);
+        ArtifactManagerTest.artifactArchive(jenkinsRule, getArtifactManagerFactory(null, null), true);
     }
 
     protected static void _artifactStashAndDelete(JenkinsRule jenkinsRule) throws Throwable {
         createBucketWithAwsClient("artifact-stash-and-delete");
-        ArtifactManagerTest.artifactStashAndDelete(jenkinsRule, getArtifactManagerFactory(null, true), true, null);
+        ArtifactManagerTest.artifactStashAndDelete(jenkinsRule, getArtifactManagerFactory(null, true), true);
     }
 
     protected static void _canCreateBucket(JenkinsRule r) throws Throwable {
@@ -84,7 +84,7 @@ public abstract class AbstractIntegrationTest {
 
     protected static void _artifactStash(JenkinsRule jenkinsRule) throws Throwable {
         createBucketWithAwsClient("artifact-stash");
-        ArtifactManagerTest.artifactStash(jenkinsRule, getArtifactManagerFactory(null, null), true, null);
+        ArtifactManagerTest.artifactStash(jenkinsRule, getArtifactManagerFactory(null, null), true);
     }
 
     @Test


### PR DESCRIPTION
#648 extended with https://github.com/jenkinsci/ssh-agents-plugin/pull/607 / https://github.com/jenkinsci/workflow-api-plugin/pull/416.