### PR TITLE
Add option to disable presigned URL generation for public S3 buckets

### DIFF
--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
@@ -120,6 +120,8 @@ public final class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
     
     private final boolean deleteStashes;
 
+    private boolean generatePresignedUrls = true;
+
     /**
      * class to test configuration against Amazon S3 Bucket.
      */
@@ -132,7 +134,7 @@ public final class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
         S3BlobStoreTester(String container, String prefix, boolean useHttp,
             boolean useTransferAcceleration, boolean usePathStyleUrl,
             boolean disableSessionToken, String customEndpoint,
-            String customSigningRegion) {
+            String customSigningRegion, boolean generatePresignedUrls) {
             config = new S3BlobStoreConfig();
             config.setContainer(container);
             config.setPrefix(prefix);
@@ -142,6 +144,7 @@ public final class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
             config.setUseTransferAcceleration(useTransferAcceleration);
             config.setUsePathStyleUrl(usePathStyleUrl);
             config.setDisableSessionToken(disableSessionToken);
+            config.setGeneratePresignedUrls(generatePresignedUrls);
         }
 
         @Override
@@ -272,6 +275,16 @@ public final class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
     public void setCustomSigningRegion(String customSigningRegion){
         this.customSigningRegion = customSigningRegion;
         checkValue(doCheckCustomSigningRegion(this.customSigningRegion));
+        save();
+    }
+
+    public boolean getGeneratePresignedUrls() {
+        return generatePresignedUrls;
+    }
+
+    @DataBoundSetter
+    public void setGeneratePresignedUrls(boolean generatePresignedUrls){
+        this.generatePresignedUrls = generatePresignedUrls;
         save();
     }
     
@@ -460,7 +473,8 @@ public final class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
             @QueryParameter boolean usePathStyleUrl,
             @QueryParameter boolean disableSessionToken, 
             @QueryParameter String customEndpoint,
-            @QueryParameter String customSigningRegion) {
+            @QueryParameter String customSigningRegion,
+            @QueryParameter boolean generatePresignedUrls) {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
         if (FIPS140.useCompliantAlgorithms() && useHttp) {
@@ -469,7 +483,7 @@ public final class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
         FormValidation ret = FormValidation.ok("success");
         S3BlobStore provider = new S3BlobStoreTester(container, prefix, 
                 useHttp, useTransferAcceleration,usePathStyleUrl,
-                disableSessionToken, customEndpoint, customSigningRegion);
+                disableSessionToken, customEndpoint, customSigningRegion, generatePresignedUrls);
         
         try {
             JCloudsVirtualFile jc = new JCloudsVirtualFile(provider, container, prefix.replaceFirst("/$", ""));

--- a/src/main/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig/config.jelly
@@ -32,8 +32,11 @@
         <f:entry title="${%Disable Session Token}" field="disableSessionToken">
             <f:checkbox/>
         </f:entry>
+        <f:entry title="${%Generate Presigned URLs}" field="generatePresignedUrls">
+            <f:checkbox checked="true"/>
+        </f:entry>
         <f:validateButton title="Validate S3 Bucket configuration" progress="Validate..." method="validateS3BucketConfig"
-                          with="container,prefix,useHttp,useTransferAcceleration,usePathStyleUrl,disableSessionToken,customEndpoint,customSigningRegion"/>
+                          with="container,prefix,useHttp,useTransferAcceleration,usePathStyleUrl,disableSessionToken,customEndpoint,customSigningRegion,generatePresignedUrls"/>
         <f:validateButton title="Create S3 Bucket from configuration" progress="Creating S3 Bucket..." method="createS3Bucket"
                           with="container,disableSessionToken"/>
     </f:section>

--- a/src/main/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig/help-generatePresignedUrls.html
+++ b/src/main/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig/help-generatePresignedUrls.html
@@ -1,0 +1,9 @@
+<div>
+    When checked, generates presigned URLs with authentication parameters for artifact access.
+    These URLs expire after 1 hour for security.
+    <br><br>
+    When unchecked, returns direct S3 URLs without authentication parameters.
+    Only use this if your S3 bucket has public read access configured.
+    <br><br>
+    Default: enabled.
+</div>

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/JCloudsArtifactManagerTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/JCloudsArtifactManagerTest.java
@@ -358,6 +358,33 @@ public class JCloudsArtifactManagerTest extends S3AbstractTest {
         }
     }
 
+    @Test
+    public void testDirectUrlGeneration() throws Exception {
+        ArtifactManagerConfiguration.get().getArtifactManagerFactories().add(getArtifactManagerFactory(null, null));
+        
+        S3BlobStoreConfig config = S3BlobStoreConfig.get();
+        boolean originalSetting = config.getGeneratePresignedUrls();
+        
+        try {
+            config.setGeneratePresignedUrls(false);
+            
+            WorkflowJob p = j.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition("node {writeFile file: 'test.txt', text: 'content'; archiveArtifacts 'test.txt'}", true));
+            WorkflowRun b = j.buildAndAssertSuccess(p);
+            
+            URL url = b.getArtifactManager().root().child("test.txt").toExternalURL();
+            String urlString = url.toString();
+            
+            assertTrue("URL should not contain presigned parameters when generatePresignedUrls is false", 
+                       !urlString.contains("X-Amz-Algorithm") && 
+                       !urlString.contains("X-Amz-Credential") &&
+                       !urlString.contains("X-Amz-Signature"));
+                       
+        } finally {
+            config.setGeneratePresignedUrls(originalSetting);
+        }
+    }
+
     public static class ArchiveArtifactWithCustomPathStep extends Step implements Serializable {
         private static final long serialVersionUID = 1L;
         private final String archivePath;

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfigTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfigTest.java
@@ -30,6 +30,7 @@ public class S3BlobStoreConfigTest {
     public static final boolean USE_PATH_STYLE = true;
     public static final boolean USE_HTTP = true;
     public static final boolean DISABLE_SESSION_TOKEN = true;
+    public static final boolean GENERATE_PRESIGNED_URLS = false;
 
     @Rule
     public JenkinsRule j = new JenkinsRule();
@@ -45,6 +46,7 @@ public class S3BlobStoreConfigTest {
         config.setUsePathStyleUrl(USE_PATH_STYLE);
         config.setUseHttp(USE_HTTP);
         config.setDisableSessionToken(DISABLE_SESSION_TOKEN);
+        config.setGeneratePresignedUrls(GENERATE_PRESIGNED_URLS);
 
         JCloudsArtifactManagerFactory artifactManagerFactory = new JCloudsArtifactManagerFactory(provider);
         ArtifactManagerConfiguration.get().getArtifactManagerFactories().add(artifactManagerFactory);
@@ -67,6 +69,7 @@ public class S3BlobStoreConfigTest {
         assertEquals(USE_PATH_STYLE, S3BlobStoreConfig.get().getUsePathStyleUrl());
         assertEquals(USE_HTTP, S3BlobStoreConfig.get().getUseHttp());
         assertEquals(DISABLE_SESSION_TOKEN, S3BlobStoreConfig.get().getDisableSessionToken());
+        assertEquals(GENERATE_PRESIGNED_URLS, S3BlobStoreConfig.get().getGeneratePresignedUrls());
     }
 
     @Test(expected = Failure.class)
@@ -133,5 +136,17 @@ public class S3BlobStoreConfigTest {
         S3BlobStoreConfig descriptor = S3BlobStoreConfig.get();
         assertEquals(descriptor.doCheckUseHttp(true).kind , FormValidation.Kind.OK);
         assertEquals(descriptor.doCheckUseHttp(false).kind , FormValidation.Kind.OK);
+    }
+
+    @Test
+    public void checkGeneratePresignedUrlsDefaultAndSetterGetter() {
+        S3BlobStoreConfig config = S3BlobStoreConfig.get();
+        assertTrue("generatePresignedUrls should default to true", config.getGeneratePresignedUrls());
+        
+        config.setGeneratePresignedUrls(false);
+        assertEquals("generatePresignedUrls should be false after setting", false, config.getGeneratePresignedUrls());
+        
+        config.setGeneratePresignedUrls(true);
+        assertEquals("generatePresignedUrls should be true after setting", true, config.getGeneratePresignedUrls());
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR adds a new configuration option `generatePresignedUrls` to the S3 artifact storage that allows users to disable the generation of presigned URLs and instead use direct S3 URLs for artifact access. This is useful when S3 buckets are configured with public read access and don't require authentication parameters in the URLs.

### Key changes:
- Added `generatePresignedUrls` boolean configuration field (defaults to `true` for backward compatibility)
- Modified `S3BlobStore.toExternalURL()` and `S3BlobStore.artifactUrls()` to return direct URLs when presigned URL generation is disabled
- Added UI checkbox in the Jenkins configuration page with help documentation
- When disabled, URLs will be in the format `https://bucket.s3.region.amazonaws.com/path/to/artifact` without authentication parameters

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

**Automated tests:**
- Added `testDirectUrlGeneration()` test in `JCloudsArtifactManagerTest` that verifies:
  - When `generatePresignedUrls` is set to `false`, the generated URLs do not contain presigned authentication parameters (X-Amz-Algorithm, X-Amz-Credential, X-Amz-Signature)
  - The test creates a workflow job, archives an artifact, and validates the URL format
- Added `checkGeneratePresignedUrlsDefaultAndSetterGetter()` test in `S3BlobStoreConfigTest` that verifies:
  - The default value is `true` (maintaining backward compatibility)
  - The setter and getter methods work correctly
- Updated existing config validation test to include the new parameter

**Manual testing:**
- Tested the configuration UI to ensure the checkbox appears and saves correctly
- Verified that existing configurations continue to work with presigned URLs (default behavior)
- Tested with a public S3 bucket to confirm direct URLs work without authentication

**UI Screenshots:**
<details>
<summary>Configuration page before changes</summary>
<img width="1714" height="1028" alt="Снимок экрана 2025-08-12 в 17 20 10" src="https://github.com/user-attachments/assets/fee26448-9482-4c8f-a035-e00535cb50ea" />
</details>

<details>
<summary>Configuration page after changes</summary>
<img width="1714" height="1028" alt="Снимок экрана 2025-08-12 в 17 19 13" src="https://github.com/user-attachments/assets/58f463de-131b-4434-b230-1680cbafc3ff" />
</details>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
