### PR TITLE
Tolerate null `S3BlobStoreConfig.prefix`

### DIFF
--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStore.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStore.java
@@ -58,6 +58,7 @@ import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials
 import com.google.common.base.Supplier;
 
 import hudson.Extension;
+import hudson.Util;
 import io.jenkins.plugins.artifact_manager_jclouds.BlobStoreProvider;
 import io.jenkins.plugins.artifact_manager_jclouds.BlobStoreProviderDescriptor;
 import io.jenkins.plugins.aws.global_configuration.CredentialsAwsGlobalConfiguration;
@@ -91,7 +92,7 @@ public class S3BlobStore extends BlobStoreProvider {
 
     @Override
     public String getPrefix() {
-        return getConfiguration().getPrefix();
+        return Util.fixNull(getConfiguration().getPrefix());
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
@@ -37,6 +37,7 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import com.google.common.annotations.VisibleForTesting;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -174,13 +175,14 @@ public final class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
         save();
     }
 
+    @CheckForNull
     public String getPrefix() {
         return prefix;
     }
 
     @DataBoundSetter
     public void setPrefix(String prefix){
-        this.prefix = prefix;
+        this.prefix = Util.fixEmptyAndTrim(prefix);
         checkValue(doCheckPrefix(prefix));
         save();
     }


### PR DESCRIPTION
For example when the plugin is configured as code and `prefix` is simply omitted. Otherwise can get `"null"` prepended to start of blob paths.