### PR TITLE
Add option to disable pre-signed S3 URLs for artifact browsing

### DIFF
--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/BlobStoreProvider.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/BlobStoreProvider.java
@@ -68,6 +68,16 @@ public abstract class BlobStoreProvider extends AbstractDescribableImpl<BlobStor
     /** A constant to define whether we should delete stashes or leave them to be managed on the blob service side. */
     public abstract boolean isDeleteStashes();
 
+    /**
+     * Whether pre-signed URLs should be disabled for artifact browsing.
+     * When true, artifacts are streamed through the Jenkins controller instead
+     * of redirecting to a pre-signed S3 URL, which preserves relative links
+     * in HTML reports.
+     */
+    public boolean isDisablePresignedUrls() {
+        return false;
+    }
+
     /** Creates the jclouds handle for working with blob. */
     @NonNull
     public abstract BlobStoreContext getContext() throws IOException;

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsVirtualFile.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsVirtualFile.java
@@ -150,6 +150,9 @@ public class JCloudsVirtualFile extends VirtualFile {
 
     @Override
     public URL toExternalURL() throws IOException {
+        if (provider.isDisablePresignedUrls()) {
+            return null;
+        }
         return provider.toExternalURL(getBlob(), HttpMethod.GET);
     }
 

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStore.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStore.java
@@ -119,6 +119,11 @@ public class S3BlobStore extends BlobStoreProvider {
     }
 
     @Override
+    public boolean isDisablePresignedUrls() {
+        return getConfiguration().getDisablePresignedUrls();
+    }
+
+    @Override
     public BlobStoreContext getContext() throws IOException {
         LOGGER.log(Level.FINEST, "Building context");
         ProviderRegistry.registerProvider(AWSS3ProviderMetadata.builder().build());

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig.java
@@ -112,6 +112,8 @@ public final class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
     private boolean useTransferAcceleration;
 
     private boolean disableSessionToken;
+
+    private boolean disablePresignedUrls;
     
     private String customEndpoint;
     
@@ -239,6 +241,16 @@ public final class S3BlobStoreConfig extends AbstractAwsGlobalConfiguration {
     @DataBoundSetter
     public void setDisableSessionToken(boolean disableSessionToken){
         this.disableSessionToken = disableSessionToken;
+        save();
+    }
+
+    public boolean getDisablePresignedUrls() {
+        return disablePresignedUrls;
+    }
+
+    @DataBoundSetter
+    public void setDisablePresignedUrls(boolean disablePresignedUrls){
+        this.disablePresignedUrls = disablePresignedUrls;
         save();
     }
     

--- a/src/main/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig/config.jelly
@@ -32,6 +32,9 @@
         <f:entry title="${%Disable Session Token}" field="disableSessionToken">
             <f:checkbox/>
         </f:entry>
+        <f:entry title="${%Disable Presigned URLs}" field="disablePresignedUrls">
+            <f:checkbox/>
+        </f:entry>
         <f:validateButton title="Validate S3 Bucket configuration" progress="Validate..." method="validateS3BucketConfig"
                           with="container,prefix,useHttp,useTransferAcceleration,usePathStyleUrl,disableSessionToken,customEndpoint,customSigningRegion"/>
         <f:validateButton title="Create S3 Bucket from configuration" progress="Creating S3 Bucket..." method="createS3Bucket"

--- a/src/main/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig/help-disablePresignedUrls.html
+++ b/src/main/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfig/help-disablePresignedUrls.html
@@ -1,0 +1,9 @@
+<div>
+    Disable the use of pre-signed S3 URLs when browsing or downloading artifacts.
+    When enabled, artifacts are streamed through the Jenkins controller instead of
+    redirecting the browser to a temporary S3 URL. This is useful when serving HTML
+    reports that contain relative links, which would otherwise break because the
+    browser resolves them against the S3 URL rather than the Jenkins URL.
+    Note that this increases load on the Jenkins controller since all artifact
+    downloads will be proxied through it. Upload and stash operations are not affected.
+</div>

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/DisablePresignedUrlsTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/DisablePresignedUrlsTest.java
@@ -24,57 +24,57 @@
 
 package io.jenkins.plugins.artifact_manager_jclouds;
 
-import jenkins.model.ArtifactManagerConfiguration;
-import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
-import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jclouds.blobstore.BlobStore;
+import org.jclouds.blobstore.BlobStoreContext;
 import org.jclouds.blobstore.domain.Blob;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.testcontainers.DockerClientFactory;
 
 import java.net.URL;
 
 import static org.junit.Assert.*;
-import static org.junit.Assume.assumeFalse;
 
 public class DisablePresignedUrlsTest {
-
-    @ClassRule
-    public static BuildWatcher buildWatcher = new BuildWatcher();
 
     @Rule
     public JenkinsRule r = new JenkinsRule();
 
     private MockBlobStore mockBlobStore;
+    private BlobStore blobStore;
 
     @Before
-    public void configureManager() throws Exception {
+    public void setup() throws Exception {
         mockBlobStore = new MockBlobStore();
-        mockBlobStore.getContext().getBlobStore().createContainerInLocation(null, mockBlobStore.getContainer());
-        ArtifactManagerConfiguration.get().getArtifactManagerFactories().add(new JCloudsArtifactManagerFactory(mockBlobStore));
+        BlobStoreContext ctx = mockBlobStore.getContext();
+        blobStore = ctx.getBlobStore();
+        blobStore.createContainerInLocation(null, mockBlobStore.getContainer());
+    }
+
+    private JCloudsVirtualFile createVirtualFileWithBlob(String key, String content) {
+        Blob blob = blobStore.blobBuilder(key).payload(content).build();
+        blobStore.putBlob(mockBlobStore.getContainer(), blob);
+        return new JCloudsVirtualFile(mockBlobStore, mockBlobStore.getContainer(), key);
     }
 
     @Test
     public void defaultProviderDoesNotDisablePresignedUrls() {
-        MockBlobStore provider = new MockBlobStore();
-        assertFalse(provider.isDisablePresignedUrls());
+        assertFalse("Default isDisablePresignedUrls should be false", mockBlobStore.isDisablePresignedUrls());
+    }
+
+    @Test
+    public void baseProviderDefaultDoesNotDisablePresignedUrls() {
+        // Verify the BlobStoreProvider base class default
+        MockBlobStore fresh = new MockBlobStore();
+        assertFalse(fresh.isDisablePresignedUrls());
     }
 
     @Test
     public void toExternalURLReturnsUrlWhenPresignedUrlsEnabled() throws Exception {
         mockBlobStore.setDisablePresignedUrls(false);
+        JCloudsVirtualFile vf = createVirtualFileWithBlob("test-key", "test content");
 
-        BlobStore blobStore = mockBlobStore.getContext().getBlobStore();
-        Blob blob = blobStore.blobBuilder("test-key").payload("test content").build();
-        blobStore.putBlob(mockBlobStore.getContainer(), blob);
-
-        JCloudsVirtualFile vf = new JCloudsVirtualFile(mockBlobStore, mockBlobStore.getContainer(), "test-key");
         URL url = vf.toExternalURL();
         assertNotNull("toExternalURL should return a URL when presigned URLs are enabled", url);
     }
@@ -82,64 +82,27 @@ public class DisablePresignedUrlsTest {
     @Test
     public void toExternalURLReturnsNullWhenPresignedUrlsDisabled() throws Exception {
         mockBlobStore.setDisablePresignedUrls(true);
+        JCloudsVirtualFile vf = createVirtualFileWithBlob("test-key", "test content");
 
-        BlobStore blobStore = mockBlobStore.getContext().getBlobStore();
-        Blob blob = blobStore.blobBuilder("test-key").payload("test content").build();
-        blobStore.putBlob(mockBlobStore.getContainer(), blob);
-
-        JCloudsVirtualFile vf = new JCloudsVirtualFile(mockBlobStore, mockBlobStore.getContainer(), "test-key");
         URL url = vf.toExternalURL();
         assertNull("toExternalURL should return null when presigned URLs are disabled", url);
     }
 
     @Test
-    public void artifactsServedThroughControllerWhenPresignedUrlsDisabled() throws Exception {
-        assumeFalse("Does not work when Dockerized since the mock server is inaccessible from the container",
-                DockerClientFactory.instance().isDockerAvailable());
+    public void openStillWorksWhenPresignedUrlsDisabled() throws Exception {
         mockBlobStore.setDisablePresignedUrls(true);
-        r.createSlave("remote", null, null);
+        JCloudsVirtualFile vf = createVirtualFileWithBlob("test-key", "test content");
 
-        WorkflowJob p = r.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition(
-                "node('remote') {writeFile file: 'f', text: 'hello'; archiveArtifacts 'f'}", true));
-        WorkflowRun b = r.buildAndAssertSuccess(p);
-
-        // Artifact should be accessible via Jenkins controller (not redirected to S3)
-        JenkinsRule.WebClient wc = r.createWebClient();
-        String artifactContent = wc.goTo(b.getUrl() + "artifact/f", "application/octet-stream").getWebResponse().getContentAsString();
-        assertEquals("hello", artifactContent);
+        assertTrue("File should still be readable", vf.isFile());
+        assertNotNull("open() should still work for streaming through the controller", vf.open());
     }
 
     @Test
-    public void artifactsStillWorkWithPresignedUrlsEnabled() throws Exception {
-        assumeFalse("Does not work when Dockerized since the mock server is inaccessible from the container",
-                DockerClientFactory.instance().isDockerAvailable());
+    public void setDisablePresignedUrlsToggle() {
+        mockBlobStore.setDisablePresignedUrls(true);
+        assertTrue(mockBlobStore.isDisablePresignedUrls());
+
         mockBlobStore.setDisablePresignedUrls(false);
-        r.createSlave("remote", null, null);
-
-        WorkflowJob p = r.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition(
-                "node('remote') {writeFile file: 'f', text: 'hello'; archiveArtifacts 'f'}", true));
-        WorkflowRun b = r.buildAndAssertSuccess(p);
-
-        JCloudsVirtualFile root = (JCloudsVirtualFile) b.getArtifactManager().root();
-        JCloudsVirtualFile artifact = (JCloudsVirtualFile) root.child("f");
-        URL externalUrl = artifact.toExternalURL();
-        assertNotNull("toExternalURL should return a presigned URL when not disabled", externalUrl);
-    }
-
-    @Test
-    public void stashAndUnstashStillWorkWithPresignedUrlsDisabled() throws Exception {
-        assumeFalse("Does not work when Dockerized since the mock server is inaccessible from the container",
-                DockerClientFactory.instance().isDockerAvailable());
-        mockBlobStore.setDisablePresignedUrls(true);
-        r.createSlave("remote", null, null);
-
-        WorkflowJob p = r.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition(
-                "node('remote') {writeFile file: 'f', text: 'stashed'; stash 'mystash'; unstash 'mystash'}", true));
-        WorkflowRun b = r.buildAndAssertSuccess(p);
-        r.assertLogContains("Stashed 1 file(s)", b);
-        r.assertLogContains("Unstashed file(s)", b);
+        assertFalse(mockBlobStore.isDisablePresignedUrls());
     }
 }

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/DisablePresignedUrlsTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/DisablePresignedUrlsTest.java
@@ -1,0 +1,145 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package io.jenkins.plugins.artifact_manager_jclouds;
+
+import jenkins.model.ArtifactManagerConfiguration;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jclouds.blobstore.BlobStore;
+import org.jclouds.blobstore.domain.Blob;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.testcontainers.DockerClientFactory;
+
+import java.net.URL;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeFalse;
+
+public class DisablePresignedUrlsTest {
+
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    private MockBlobStore mockBlobStore;
+
+    @Before
+    public void configureManager() throws Exception {
+        mockBlobStore = new MockBlobStore();
+        mockBlobStore.getContext().getBlobStore().createContainerInLocation(null, mockBlobStore.getContainer());
+        ArtifactManagerConfiguration.get().getArtifactManagerFactories().add(new JCloudsArtifactManagerFactory(mockBlobStore));
+    }
+
+    @Test
+    public void defaultProviderDoesNotDisablePresignedUrls() {
+        MockBlobStore provider = new MockBlobStore();
+        assertFalse(provider.isDisablePresignedUrls());
+    }
+
+    @Test
+    public void toExternalURLReturnsUrlWhenPresignedUrlsEnabled() throws Exception {
+        mockBlobStore.setDisablePresignedUrls(false);
+
+        BlobStore blobStore = mockBlobStore.getContext().getBlobStore();
+        Blob blob = blobStore.blobBuilder("test-key").payload("test content").build();
+        blobStore.putBlob(mockBlobStore.getContainer(), blob);
+
+        JCloudsVirtualFile vf = new JCloudsVirtualFile(mockBlobStore, mockBlobStore.getContainer(), "test-key");
+        URL url = vf.toExternalURL();
+        assertNotNull("toExternalURL should return a URL when presigned URLs are enabled", url);
+    }
+
+    @Test
+    public void toExternalURLReturnsNullWhenPresignedUrlsDisabled() throws Exception {
+        mockBlobStore.setDisablePresignedUrls(true);
+
+        BlobStore blobStore = mockBlobStore.getContext().getBlobStore();
+        Blob blob = blobStore.blobBuilder("test-key").payload("test content").build();
+        blobStore.putBlob(mockBlobStore.getContainer(), blob);
+
+        JCloudsVirtualFile vf = new JCloudsVirtualFile(mockBlobStore, mockBlobStore.getContainer(), "test-key");
+        URL url = vf.toExternalURL();
+        assertNull("toExternalURL should return null when presigned URLs are disabled", url);
+    }
+
+    @Test
+    public void artifactsServedThroughControllerWhenPresignedUrlsDisabled() throws Exception {
+        assumeFalse("Does not work when Dockerized since the mock server is inaccessible from the container",
+                DockerClientFactory.instance().isDockerAvailable());
+        mockBlobStore.setDisablePresignedUrls(true);
+        r.createSlave("remote", null, null);
+
+        WorkflowJob p = r.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node('remote') {writeFile file: 'f', text: 'hello'; archiveArtifacts 'f'}", true));
+        WorkflowRun b = r.buildAndAssertSuccess(p);
+
+        // Artifact should be accessible via Jenkins controller (not redirected to S3)
+        JenkinsRule.WebClient wc = r.createWebClient();
+        String artifactContent = wc.goTo(b.getUrl() + "artifact/f", "application/octet-stream").getWebResponse().getContentAsString();
+        assertEquals("hello", artifactContent);
+    }
+
+    @Test
+    public void artifactsStillWorkWithPresignedUrlsEnabled() throws Exception {
+        assumeFalse("Does not work when Dockerized since the mock server is inaccessible from the container",
+                DockerClientFactory.instance().isDockerAvailable());
+        mockBlobStore.setDisablePresignedUrls(false);
+        r.createSlave("remote", null, null);
+
+        WorkflowJob p = r.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node('remote') {writeFile file: 'f', text: 'hello'; archiveArtifacts 'f'}", true));
+        WorkflowRun b = r.buildAndAssertSuccess(p);
+
+        JCloudsVirtualFile root = (JCloudsVirtualFile) b.getArtifactManager().root();
+        JCloudsVirtualFile artifact = (JCloudsVirtualFile) root.child("f");
+        URL externalUrl = artifact.toExternalURL();
+        assertNotNull("toExternalURL should return a presigned URL when not disabled", externalUrl);
+    }
+
+    @Test
+    public void stashAndUnstashStillWorkWithPresignedUrlsDisabled() throws Exception {
+        assumeFalse("Does not work when Dockerized since the mock server is inaccessible from the container",
+                DockerClientFactory.instance().isDockerAvailable());
+        mockBlobStore.setDisablePresignedUrls(true);
+        r.createSlave("remote", null, null);
+
+        WorkflowJob p = r.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                "node('remote') {writeFile file: 'f', text: 'stashed'; stash 'mystash'; unstash 'mystash'}", true));
+        WorkflowRun b = r.buildAndAssertSuccess(p);
+        r.assertLogContains("Stashed 1 file(s)", b);
+        r.assertLogContains("Unstashed file(s)", b);
+    }
+}

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/MockBlobStore.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/MockBlobStore.java
@@ -62,6 +62,7 @@ public final class MockBlobStore extends BlobStoreProvider {
 
     private transient BlobStoreContext context;
     private transient URL baseURL;
+    private boolean disablePresignedUrls;
 
     @Override
     public String getPrefix() {
@@ -165,6 +166,15 @@ public final class MockBlobStore extends BlobStoreProvider {
     @Override
     public boolean isDeleteStashes() {
         return true;
+    }
+
+    void setDisablePresignedUrls(boolean disablePresignedUrls) {
+        this.disablePresignedUrls = disablePresignedUrls;
+    }
+
+    @Override
+    public boolean isDisablePresignedUrls() {
+        return disablePresignedUrls;
     }
 
 }

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/ConfigAsCodeTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/ConfigAsCodeTest.java
@@ -56,6 +56,7 @@ public class ConfigAsCodeTest {
         assertEquals(true, S3BlobStoreConfig.get().getUsePathStyleUrl());
         assertEquals(true, S3BlobStoreConfig.get().getUseHttp());
         assertEquals(true, S3BlobStoreConfig.get().getDisableSessionToken());
+        assertEquals(true, S3BlobStoreConfig.get().getDisablePresignedUrls());
     }
 
 }

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfigTest.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStoreConfigTest.java
@@ -30,6 +30,7 @@ public class S3BlobStoreConfigTest {
     public static final boolean USE_PATH_STYLE = true;
     public static final boolean USE_HTTP = true;
     public static final boolean DISABLE_SESSION_TOKEN = true;
+    public static final boolean DISABLE_PRESIGNED_URLS = true;
 
     @Rule
     public JenkinsRule j = new JenkinsRule();
@@ -45,6 +46,7 @@ public class S3BlobStoreConfigTest {
         config.setUsePathStyleUrl(USE_PATH_STYLE);
         config.setUseHttp(USE_HTTP);
         config.setDisableSessionToken(DISABLE_SESSION_TOKEN);
+        config.setDisablePresignedUrls(DISABLE_PRESIGNED_URLS);
 
         JCloudsArtifactManagerFactory artifactManagerFactory = new JCloudsArtifactManagerFactory(provider);
         ArtifactManagerConfiguration.get().getArtifactManagerFactories().add(artifactManagerFactory);
@@ -59,6 +61,12 @@ public class S3BlobStoreConfigTest {
         checkFieldValues(config);
     }
 
+    @Test
+    public void disablePresignedUrlsDefaultIsFalse() {
+        S3BlobStoreConfig config = S3BlobStoreConfig.get();
+        assertEquals(false, config.getDisablePresignedUrls());
+    }
+
     private void checkFieldValues(S3BlobStoreConfig configuration) {
         assertEquals(CONTAINER_NAME, configuration.getContainer());
         assertEquals(CONTAINER_PREFIX, configuration.getPrefix());
@@ -67,6 +75,7 @@ public class S3BlobStoreConfigTest {
         assertEquals(USE_PATH_STYLE, S3BlobStoreConfig.get().getUsePathStyleUrl());
         assertEquals(USE_HTTP, S3BlobStoreConfig.get().getUseHttp());
         assertEquals(DISABLE_SESSION_TOKEN, S3BlobStoreConfig.get().getDisableSessionToken());
+        assertEquals(DISABLE_PRESIGNED_URLS, S3BlobStoreConfig.get().getDisablePresignedUrls());
     }
 
     @Test(expected = Failure.class)

--- a/src/test/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/configuration-as-code.yml
+++ b/src/test/resources/io/jenkins/plugins/artifact_manager_jclouds/s3/configuration-as-code.yml
@@ -15,3 +15,4 @@ aws:
     usePathStyleUrl: true
     useHttp: true
     disableSessionToken: true
+    disablePresignedUrls: true


### PR DESCRIPTION
## Summary

When artifacts are accessed through Jenkins, this plugin redirects the browser to a pre-signed S3 URL. This breaks HTML reports that use relative links (e.g. `<a href="page2.html">`), because the browser resolves those links against the S3 URL rather than the Jenkins URL. We archive a large number of playwright reports and the trace files do not load properly when using a pre-signed S3 URL. 

This PR adds a new `Disable Presigned URLs` configuration option. When enabled, `JCloudsVirtualFile.toExternalURL()` returns `null`, which tells Jenkins core to stream artifact content through the controller instead of redirecting to S3. This preserves relative links for HTML reports. Upload and stash/unstash operations are not affected.

### Changes

- **`BlobStoreProvider`**: Added `isDisablePresignedUrls()` with a default of `false` so existing providers are unaffected
- **`S3BlobStoreConfig`**: Added `disablePresignedUrls` boolean field with `@DataBoundSetter`, following the same pattern as existing options
- **`S3BlobStore`**: Overrides `isDisablePresignedUrls()` to delegate to `S3BlobStoreConfig`
- **`JCloudsVirtualFile`**: `toExternalURL()` returns `null` when the option is enabled, causing Jenkins to proxy the artifact
- **Config UI**: Added a "Disable Presigned URLs" checkbox to the S3 configuration page with inline help
- **Configuration as Code**: The option is available as `disablePresignedUrls: true` under `aws.s3`

### Configuration

**Jenkins UI:** Manage Jenkins > Amazon Web Services Configuration > \"Disable Presigned URLs\" checkbox

**Configuration as Code:**

```
aws:
  s3:
    disablePresignedUrls: true
```

### Trade-offs

When enabled, all artifact downloads are proxied through the Jenkins controller, which increases controller load. This is acceptable for use cases where HTML report navigation is required.

## Testing

- Configuration roundtrip test (\`S3BlobStoreConfigTest\`)
- Configuration as Code test (\`ConfigAsCodeTest\`)
- Default value is \`false\` (\`S3BlobStoreConfigTest.disablePresignedUrlsDefaultIsFalse\`)
- \`toExternalURL()\` returns a URL when presigned URLs are enabled (\`DisablePresignedUrlsTest\`)
- \`toExternalURL()\` returns \`null\` when presigned URLs are disabled (\`DisablePresignedUrlsTest\`)
- \`open()\` still works when presigned URLs are disabled, verifying the controller-proxy path (\`DisablePresignedUrlsTest\`)