### PR TITLE
Make expiration of URLs configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,10 +210,12 @@ Artifact Manager on S3 plugin would try to use the IAM instance profile credenti
 
 ![](images/configure-credentials.png)
 
-Every time you archive/unarchive or download an artifact, Jenkins will generate a temporary URL, it will be valid for an hour, 
-so if you try to reuse an artifact download URL one hour later was generated, it will not be valid, 
+Every time you archive/unarchive or download an artifact, Jenkins will generate a temporary URL, it will be valid for a minute, 
+so if you try to reuse an artifact download URL one minute after it was generated, it will not be valid, 
 you cannot download the artifact with that URL any more, thus you have to go back to Jenkins 
-and click on the artifact to download it again. 
+and click on the artifact to download it again from a new URL.
+This can be configured by setting the Java system property
+`io.jenkins.plugins.artifact_manager_jclouds.JCloudsVirtualFile.externalUrlDuration` to the expected duration.
 
 If you use a regular Key/Secret AWS Credentials you can set the token duration by adding the property 
 `-Dio.jenkins.plugins.aws.global_configuration.CredentialsAwsGlobalConfiguration.sessionDuration` to the Jenkins JVM properties,

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.504</jenkins.baseline>
+    <jenkins.baseline>2.516</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/BlobStoreProvider.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/BlobStoreProvider.java
@@ -28,9 +28,11 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URL;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
+import jenkins.util.SystemProperties;
 import org.jclouds.blobstore.BlobStore;
 import org.jclouds.blobstore.BlobStoreContext;
 import org.jclouds.blobstore.domain.Blob;
@@ -95,7 +97,11 @@ public abstract class BlobStoreProvider extends AbstractDescribableImpl<BlobStor
      * @throws IOException
      */
     @NonNull
-    public abstract URL toExternalURL(@NonNull Blob blob, @NonNull HttpMethod httpMethod) throws IOException;
+    public URL toExternalURL(@NonNull Blob blob, @NonNull HttpMethod httpMethod) throws IOException {
+        return toExternalURL(blob, httpMethod, Duration.ofSeconds(SystemProperties.getInteger(BlobStoreProvider.class.getName() + ".DEFAULT_DURATION_SECONDS", 3600)));
+    }
+
+    public abstract URL toExternalURL(Blob blob, HttpMethod httpMethod, Duration duration) throws IOException;
 
     @Override
     public BlobStoreProviderDescriptor getDescriptor() {

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/BlobStoreProvider.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/BlobStoreProvider.java
@@ -93,14 +93,14 @@ public abstract class BlobStoreProvider extends AbstractDescribableImpl<BlobStor
      *            blob to generate the URL for
      * @param httpMethod
      *            HTTP method to create a URL for (downloads or uploads)
+     * @param duration
+     *            The expected duration that the URL is to be valid for.
+     *            Implementations without a concept of URL expiration can ignore this.
+     *            Implementations can limit validity inside required bounds if the argument is too small/big, but impractical/broken arguments should be honored whenq possible.
      * @return the URL
      * @throws IOException
      */
     @NonNull
-    public URL toExternalURL(@NonNull Blob blob, @NonNull HttpMethod httpMethod) throws IOException {
-        return toExternalURL(blob, httpMethod, Duration.ofSeconds(SystemProperties.getInteger(BlobStoreProvider.class.getName() + ".DEFAULT_DURATION_SECONDS", 3600)));
-    }
-
     public abstract URL toExternalURL(Blob blob, HttpMethod httpMethod, Duration duration) throws IOException;
 
     @Override
@@ -117,7 +117,7 @@ public abstract class BlobStoreProvider extends AbstractDescribableImpl<BlobStor
             Blob blob = blobStore.blobBuilder(blobPath).build();
             blob.getMetadata().setContainer(this.getContainer());
             blob.getMetadata().getContentMetadata().setContentType(contentTypes.get(entry.getValue()));
-            artifactUrls.put(entry.getValue(), this.toExternalURL(blob, HttpMethod.PUT));
+            artifactUrls.put(entry.getValue(), this.toExternalURL(blob, HttpMethod.PUT, SystemProperties.getDuration(BlobStoreProvider.class.getName() + ".artifactUrlDuration", Duration.ofHours(1))));
         }
         return artifactUrls;
     }

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsArtifactManager.java
@@ -51,6 +51,7 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -59,6 +60,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.MasterToSlaveFileCallable;
 import jenkins.model.ArtifactManager;
+import jenkins.util.SystemProperties;
 import jenkins.util.VirtualFile;
 import org.apache.http.client.methods.HttpGet;
 import org.jclouds.blobstore.BlobStore;
@@ -217,7 +219,7 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
         blob.getMetadata().setContainer(provider.getContainer());
         // We don't care about content-type when stashing files
         blob.getMetadata().getContentMetadata().setContentType(null);
-        URL url = provider.toExternalURL(blob, HttpMethod.PUT);
+        URL url = provider.toExternalURL(blob, HttpMethod.PUT, SystemProperties.getDuration(JCloudsArtifactManager.class.getName() + ".stashDuration", Duration.ofHours(1)));
         FilePath tempDir = WorkspaceList.tempDir(workspace);
         if (tempDir == null) {
             throw new AbortException("Could not make temporary directory in " + workspace);
@@ -287,7 +289,7 @@ public final class JCloudsArtifactManager extends ArtifactManager implements Sta
             throw new AbortException(
                     String.format("No such saved stash ‘%s’ found at %s/%s", name, provider.getContainer(), blobPath));
         }
-        URL url = provider.toExternalURL(blob, HttpMethod.GET);
+        URL url = provider.toExternalURL(blob, HttpMethod.GET, SystemProperties.getDuration(JCloudsArtifactManager.class.getName() + ".unstashDuration", Duration.ofHours(1)));
         workspace.act(new Unstash(url, listener));
         listener.getLogger().printf("Unstashed file(s) from %s%n", provider.toURI(provider.getContainer(), blobPath));
     }

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsVirtualFile.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsVirtualFile.java
@@ -152,7 +152,7 @@ public class JCloudsVirtualFile extends VirtualFile {
 
     @Override
     public URL toExternalURL() throws IOException {
-        return provider.toExternalURL(getBlob(), HttpMethod.GET, Duration.ofSeconds(SystemProperties.getInteger(JCloudsVirtualFile.class.getName() + ".EXPIRATION_SECONDS", 60)));
+        return provider.toExternalURL(getBlob(), HttpMethod.GET, SystemProperties.getDuration(JCloudsVirtualFile.class.getName() + ".externalUrlDuration", Duration.ofMinutes(1)));
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsVirtualFile.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/JCloudsVirtualFile.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
+import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,6 +44,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.StreamSupport;
 
+import jenkins.util.SystemProperties;
 import org.jclouds.blobstore.BlobStore;
 import org.jclouds.blobstore.BlobStoreContext;
 import org.jclouds.blobstore.BlobStores;
@@ -150,7 +152,7 @@ public class JCloudsVirtualFile extends VirtualFile {
 
     @Override
     public URL toExternalURL() throws IOException {
-        return provider.toExternalURL(getBlob(), HttpMethod.GET);
+        return provider.toExternalURL(getBlob(), HttpMethod.GET, Duration.ofSeconds(SystemProperties.getInteger(JCloudsVirtualFile.class.getName() + ".EXPIRATION_SECONDS", 60)));
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStore.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStore.java
@@ -239,8 +239,7 @@ public class S3BlobStore extends BlobStoreProvider {
         return presignerBuilder.build();
     }
 
-    private URL toExternalURL(@NonNull Blob blob, @NonNull HttpMethod httpMethod, S3Presigner presigner) throws IOException {
-        Duration expiration = Duration.ofHours(1);
+    private URL toExternalURL(@NonNull Blob blob, @NonNull HttpMethod httpMethod, S3Presigner presigner, @NonNull Duration expiration) throws IOException {
         String container = blob.getMetadata().getContainer();
         String name = blob.getMetadata().getName();
         LOGGER.log(Level.FINE, "Generating presigned URL for {0} / {1} for method {2}",
@@ -248,6 +247,9 @@ public class S3BlobStore extends BlobStoreProvider {
         String contentType;
         switch (httpMethod) {
             case PUT:
+                if (expiration.isZero()) {
+                    throw new IllegalArgumentException("Expiration time must be greater than zero for PUT");
+                }
                 // Only set content type for upload URLs, so that the right S3 metadata gets set
                 contentType = blob.getMetadata().getContentMetadata().getContentType();
                 PutObjectRequest putObjectRequest = PutObjectRequest.builder().bucket(container)
@@ -259,6 +261,9 @@ public class S3BlobStore extends BlobStoreProvider {
                         .putObjectRequest(putObjectRequest).build();
                 return presigner.presignPutObject(putObjectPresignRequest).url();
             case GET:
+                if (expiration.isZero()) {
+                    return blob.getMetadata().getUri().toURL();
+                }
                 GetObjectRequest getObjectRequest = GetObjectRequest.builder().bucket(container).key(name).build();
                 GetObjectPresignRequest getObjectPresignRequest = GetObjectPresignRequest.builder()
                         .signatureDuration(expiration)
@@ -274,10 +279,10 @@ public class S3BlobStore extends BlobStoreProvider {
      *      Pre-signed Object URL using AWS SDK for Java</a>
      */
     @Override
-    public URL toExternalURL(@NonNull Blob blob, @NonNull HttpMethod httpMethod) throws IOException {
+    public URL toExternalURL(@NonNull Blob blob, @NonNull HttpMethod httpMethod, Duration expiration) throws IOException {
         try (S3Client s3Client = getConfiguration().getAmazonS3ClientBuilderWithCredentials().build();
              S3Presigner presigner = getS3Presigner(s3Client)) {
-            return toExternalURL(blob, httpMethod, presigner);
+            return toExternalURL(blob, httpMethod, presigner, expiration);
         }
     }
 
@@ -293,7 +298,7 @@ public class S3BlobStore extends BlobStoreProvider {
                 Blob blob = blobStore.blobBuilder(blobPath).build();
                 blob.getMetadata().setContainer(this.getContainer());
                 blob.getMetadata().getContentMetadata().setContentType(contentTypes.get(entry.getValue()));
-                artifactUrls.put(entry.getValue(), this.toExternalURL(blob, HttpMethod.PUT, s3Presigner));
+                artifactUrls.put(entry.getValue(), this.toExternalURL(blob, HttpMethod.PUT, s3Presigner, Duration.ofHours(1)));
             }
         }
         return artifactUrls;

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStore.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStore.java
@@ -242,8 +242,20 @@ public class S3BlobStore extends BlobStoreProvider {
     private URL toExternalURL(@NonNull Blob blob, @NonNull HttpMethod httpMethod, S3Presigner presigner, @NonNull Duration expiration) throws IOException {
         String container = blob.getMetadata().getContainer();
         String name = blob.getMetadata().getName();
-        LOGGER.log(Level.FINE, "Generating presigned URL for {0} / {1} for method {2}",
-                new Object[]{container, name, httpMethod});
+        if (expiration.getSeconds() <= 0) {
+            // Requests that are pre-signed by SigV4 algorithm are valid for at least 1 second and at most 7 days. The expiration duration set on the current request [PT0S] does not meet these bounds.
+            expiration = Duration.ofSeconds(1);
+            LOGGER.log(Level.FINE, "Received an invalid duration for {0} / {1} for method {2}, setting to 1 second: {3}",
+                    new Object[]{container, name, httpMethod, expiration});
+        }
+        if (!expiration.minusDays(7).isNegative()) {
+            // https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html#PresignedUrl-Expiration
+            expiration = Duration.ofDays(7);
+            LOGGER.log(Level.FINE, "Received an invalid duration for {0} / {1} for method {2}, setting to 7 days: {3}",
+                    new Object[]{container, name, httpMethod, expiration});
+        }
+        LOGGER.log(Level.FINE, "Generating presigned URL for {0} / {1} for method {2} with duration {3}",
+                new Object[]{container, name, httpMethod, expiration});
         String contentType;
         switch (httpMethod) {
             case PUT:

--- a/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStore.java
+++ b/src/main/java/io/jenkins/plugins/artifact_manager_jclouds/s3/S3BlobStore.java
@@ -39,6 +39,7 @@ import java.util.logging.Logger;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import jenkins.security.FIPS140;
+import jenkins.util.SystemProperties;
 import org.apache.commons.lang.StringUtils;
 import org.jclouds.ContextBuilder;
 import org.jclouds.aws.domain.SessionCredentials;
@@ -85,7 +86,7 @@ public class S3BlobStore extends BlobStoreProvider {
     private static final Logger LOGGER = Logger.getLogger(S3BlobStore.class.getName());
 
     private static final long serialVersionUID = -8864075675579867370L;
-    
+
     @DataBoundConstructor
     public S3BlobStore() {
     }
@@ -246,9 +247,6 @@ public class S3BlobStore extends BlobStoreProvider {
         String contentType;
         switch (httpMethod) {
             case PUT:
-                if (expiration.isZero()) {
-                    throw new IllegalArgumentException("Expiration time must be greater than zero for PUT");
-                }
                 // Only set content type for upload URLs, so that the right S3 metadata gets set
                 contentType = blob.getMetadata().getContentMetadata().getContentType();
                 PutObjectRequest putObjectRequest = PutObjectRequest.builder().bucket(container)
@@ -260,9 +258,6 @@ public class S3BlobStore extends BlobStoreProvider {
                         .putObjectRequest(putObjectRequest).build();
                 return presigner.presignPutObject(putObjectPresignRequest).url();
             case GET:
-                if (expiration.isZero()) {
-                    return blob.getMetadata().getUri().toURL();
-                }
                 GetObjectRequest getObjectRequest = GetObjectRequest.builder().bucket(container).key(name).build();
                 GetObjectPresignRequest getObjectPresignRequest = GetObjectPresignRequest.builder()
                         .signatureDuration(expiration)
@@ -278,6 +273,7 @@ public class S3BlobStore extends BlobStoreProvider {
      *      Pre-signed Object URL using AWS SDK for Java</a>
      */
     @Override
+    @NonNull
     public URL toExternalURL(@NonNull Blob blob, @NonNull HttpMethod httpMethod, Duration expiration) throws IOException {
         try (S3Client s3Client = getConfiguration().getAmazonS3ClientBuilderWithCredentials().build();
              S3Presigner presigner = getS3Presigner(s3Client)) {
@@ -297,7 +293,7 @@ public class S3BlobStore extends BlobStoreProvider {
                 Blob blob = blobStore.blobBuilder(blobPath).build();
                 blob.getMetadata().setContainer(this.getContainer());
                 blob.getMetadata().getContentMetadata().setContentType(contentTypes.get(entry.getValue()));
-                artifactUrls.put(entry.getValue(), this.toExternalURL(blob, HttpMethod.PUT, s3Presigner, Duration.ofHours(1)));
+                artifactUrls.put(entry.getValue(), this.toExternalURL(blob, HttpMethod.PUT, s3Presigner, SystemProperties.getDuration(S3BlobStore.class.getName() + ".artifactUrlDuration", Duration.ofHours(1))));
             }
         }
         return artifactUrls;

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/MockBlobStore.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/MockBlobStore.java
@@ -27,6 +27,7 @@ package io.jenkins.plugins.artifact_manager_jclouds;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
@@ -153,7 +154,7 @@ public final class MockBlobStore extends BlobStoreProvider {
     }
 
     @Override
-    public URL toExternalURL(Blob blob, HttpMethod httpMethod) throws IOException {
+    public URL toExternalURL(Blob blob, HttpMethod httpMethod, Duration expiration) throws IOException {
         return new URL(baseURL, blob.getMetadata().getContainer() + "/" + blob.getMetadata().getName() + "?method=" + httpMethod);
     }
 

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/MockBlobStore.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/MockBlobStore.java
@@ -24,6 +24,7 @@
 
 package io.jenkins.plugins.artifact_manager_jclouds;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
@@ -154,6 +155,7 @@ public final class MockBlobStore extends BlobStoreProvider {
     }
 
     @Override
+    @NonNull
     public URL toExternalURL(Blob blob, HttpMethod httpMethod, Duration expiration) throws IOException {
         return new URL(baseURL, blob.getMetadata().getContainer() + "/" + blob.getMetadata().getName() + "?method=" + httpMethod);
     }

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/CustomBehaviorBlobStoreProvider.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/CustomBehaviorBlobStoreProvider.java
@@ -29,6 +29,7 @@ import io.jenkins.plugins.artifact_manager_jclouds.BlobStoreProviderDescriptor;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.time.Duration;
 import org.jclouds.blobstore.BlobStoreContext;
 import org.jclouds.blobstore.domain.Blob;
 
@@ -76,6 +77,11 @@ public class CustomBehaviorBlobStoreProvider extends BlobStoreProvider {
     @Override
     public URL toExternalURL(Blob blob, BlobStoreProvider.HttpMethod httpMethod) throws IOException {
         return delegate.toExternalURL(blob, httpMethod);
+    }
+
+    @Override
+    public URL toExternalURL(Blob blob, HttpMethod httpMethod, Duration duration) throws IOException {
+        return delegate.toExternalURL(blob, httpMethod, duration);
     }
 
     @Override

--- a/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/CustomBehaviorBlobStoreProvider.java
+++ b/src/test/java/io/jenkins/plugins/artifact_manager_jclouds/s3/CustomBehaviorBlobStoreProvider.java
@@ -24,6 +24,7 @@
 
 package io.jenkins.plugins.artifact_manager_jclouds.s3;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.jenkins.plugins.artifact_manager_jclouds.BlobStoreProvider;
 import io.jenkins.plugins.artifact_manager_jclouds.BlobStoreProviderDescriptor;
 import java.io.IOException;
@@ -75,11 +76,7 @@ public class CustomBehaviorBlobStoreProvider extends BlobStoreProvider {
     }
 
     @Override
-    public URL toExternalURL(Blob blob, BlobStoreProvider.HttpMethod httpMethod) throws IOException {
-        return delegate.toExternalURL(blob, httpMethod);
-    }
-
-    @Override
+    @NonNull
     public URL toExternalURL(Blob blob, HttpMethod httpMethod, Duration duration) throws IOException {
         return delegate.toExternalURL(blob, httpMethod, duration);
     }


### PR DESCRIPTION
We got a report from someone who wanted to reduce the pre-signed URL validity period from the default of 1 hr.
[CloudBees-internal reference](https://cloudbees.atlassian.net/browse/JENSEC-2386)

This PR implements that as a set of system properties:

* `io.jenkins.plugins.artifact_manager_jclouds.JCloudsVirtualFile.externalUrlDuration`:
  The validity of the (pre-signed) URL that a user is redirected to when accessing an artifact, in seconds. The default is reduced from 1 hr to 1 minute.
* `io.jenkins.plugins.artifact_manager_jclouds.JCloudsArtifactManager.stashDuration`:
  The validity of the (pre-signed) URL for `stash` operations. This remains 1 hr by default. This addition will also allow users for whom 1 hr of stashing isn't enough to tune the expiration of that to be longer.
* `io.jenkins.plugins.artifact_manager_jclouds.JCloudsArtifactManager.unstashDuration`:
  The validity of the (pre-signed) URL for `unstash` operations. This remains 1 hr by default. This addition will also allow users for whom 1 hr of unstashing isn't enough to tune the expiration of that to be longer.
* `io.jenkins.plugins.artifact_manager_jclouds.s3.S3BlobStore.artifactUrlDuration`:
  The validity of the external URL for `archive` operations in the S3 implementation. This remains 1 hr by default. This addition will also allow users for whom 1 hr of archiving isn't enough to tune the expiration of that to be longer.
* `io.jenkins.plugins.artifact_manager_jclouds.BlobStoreProvider.artifactUrlDuration`:
  The validity of the external URL for `archive` operations in non-S3 implementations (of which there seem to be none). This remains 1 hr by default. This addition will also allow users for whom 1 hr of archiving isn't enough to tune the expiration of that to be longer.

This is for your consideration. Test coverage (actual, e.g., minio-based coverage so far is pretty minimal, so a bit more effort) and docs will follow if accepted in principle.

### Testing done

Manual so far, with both AWS S3, and a local Minio server.

Script console (example):
```
System.setProperty('io.jenkins.plugins.artifact_manager_jclouds.JCloudsVirtualFile.externalUrlDuration', '1s')
System.setProperty('io.jenkins.plugins.artifact_manager_jclouds.JCloudsArtifactManager.stashDuration', '1s')
System.setProperty('io.jenkins.plugins.artifact_manager_jclouds.JCloudsArtifactManager.unstashDuration', '1s')
System.setProperty('io.jenkins.plugins.artifact_manager_jclouds.s3.S3BlobStore.artifactUrlDuration', '1s')
System.setProperty('io.jenkins.plugins.artifact_manager_jclouds.BlobStoreProvider.artifactUrlDuration', '1s')
```

AWS requires a minimum of 1 second validity, and a max of 7 days. This is implemented in this PR.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
