### PR TITLE
Handle mixed-case S3 `StorageClass` values returned by S3-compatible providers.

### DIFF
--- a/src/main/java/org/jclouds/s3/functions/ParseObjectMetadataFromHeaders.java
+++ b/src/main/java/org/jclouds/s3/functions/ParseObjectMetadataFromHeaders.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.s3.functions;
+
+import static com.google.common.io.BaseEncoding.base16;
+import static org.jclouds.blobstore.reference.BlobStoreConstants.PROPERTY_USER_METADATA_PREFIX;
+import static org.jclouds.s3.util.StorageClassParser.parseStorageClass;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import org.jclouds.blobstore.domain.BlobMetadata;
+import org.jclouds.blobstore.functions.ParseSystemAndUserMetadataFromHeaders;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.http.HttpResponse;
+import org.jclouds.rest.InvocationContext;
+import org.jclouds.s3.blobstore.functions.BlobToObjectMetadata;
+import org.jclouds.s3.domain.MutableObjectMetadata;
+import org.jclouds.s3.domain.ObjectMetadata.StorageClass;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
+import com.google.common.net.HttpHeaders;
+
+/** This parses {@ link MutableObjectMetadata} from HTTP headers. */
+public class ParseObjectMetadataFromHeaders implements Function<HttpResponse, MutableObjectMetadata>,
+         InvocationContext<ParseObjectMetadataFromHeaders> {
+   private final ParseSystemAndUserMetadataFromHeaders blobMetadataParser;
+   private final BlobToObjectMetadata blobToObjectMetadata;
+   private final String userMdPrefix;
+
+   @Inject
+   public ParseObjectMetadataFromHeaders(ParseSystemAndUserMetadataFromHeaders blobMetadataParser,
+            BlobToObjectMetadata blobToObjectMetadata, @Named(PROPERTY_USER_METADATA_PREFIX) String userMdPrefix) {
+      this.blobMetadataParser = blobMetadataParser;
+      this.blobToObjectMetadata = blobToObjectMetadata;
+      this.userMdPrefix = userMdPrefix;
+   }
+
+   // eTag pattern can be "a34d7e626b350d2e326196085dfa52f4-1", which is opaque and shouldn't be
+   // used as content-md5, so filter etags that contain hyphens
+   static final Pattern MD5_FROM_ETAG = Pattern.compile("^\"?([0-9a-f]+)\"?$");
+
+   /** parses the http response headers to create a new {@link MutableObjectMetadata} object. */
+   public MutableObjectMetadata apply(HttpResponse from) {
+      BlobMetadata base = blobMetadataParser.apply(from);
+      MutableObjectMetadata to = blobToObjectMetadata.apply(base);
+
+      addETagTo(from, to);
+      if (to.getContentMetadata().getContentMD5() == null && to.getETag() != null) {
+         Matcher md5Matcher = MD5_FROM_ETAG.matcher(to.getETag());
+         if (md5Matcher.find()) {
+            byte[] md5 = base16().lowerCase().decode(md5Matcher.group(1));
+            // it is possible others will look at the http payload directly
+            if (from.getPayload() != null)
+               from.getPayload().getContentMetadata().setContentMD5(md5);
+            to.getContentMetadata().setContentMD5(md5);
+         }
+      }
+      // amz has an etag, but matches syntax for usermetadata
+      to.getUserMetadata().remove("object-etag");
+      to.setCacheControl(from.getFirstHeaderOrNull(HttpHeaders.CACHE_CONTROL));
+      String storageClass = from.getFirstHeaderOrNull("x-amz-storage-class");
+      if (storageClass != null) {
+         StorageClass parsedStorageClass = parseStorageClass(storageClass);
+         if (parsedStorageClass != null) {
+            to.setStorageClass(parsedStorageClass);
+         }
+      }
+      return to;
+   }
+
+   /**
+    * ETag == Content-MD5
+    */
+   @VisibleForTesting
+   protected void addETagTo(HttpResponse from, MutableObjectMetadata metadata) {
+      if (metadata.getETag() == null) {
+         String eTagHeader = from.getFirstHeaderOrNull(userMdPrefix + "object-eTag");
+         if (eTagHeader != null) {
+            metadata.setETag(eTagHeader);
+         }
+      }
+   }
+
+   @Override
+   public ParseObjectMetadataFromHeaders setContext(HttpRequest request) {
+      blobMetadataParser.setContext(request);
+      blobToObjectMetadata.setContext(request);
+      return this;
+   }
+
+   public ParseObjectMetadataFromHeaders setKey(String key) {
+      blobMetadataParser.setName(key);
+      return this;
+   }
+}

--- a/src/main/java/org/jclouds/s3/util/StorageClassParser.java
+++ b/src/main/java/org/jclouds/s3/util/StorageClassParser.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.s3.util;
+
+import java.util.Locale;
+
+import org.jclouds.s3.domain.ObjectMetadata.StorageClass;
+
+public final class StorageClassParser {
+   private StorageClassParser() {
+   }
+
+   public static StorageClass parseStorageClass(String storageClass) {
+      if (storageClass == null) {
+         return null;
+      }
+      return StorageClass.valueOf(storageClass.trim().replace('-', '_').toUpperCase(Locale.ROOT));
+   }
+}

--- a/src/main/java/org/jclouds/s3/xml/ListBucketHandler.java
+++ b/src/main/java/org/jclouds/s3/xml/ListBucketHandler.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.s3.xml;
+
+import static com.google.common.io.BaseEncoding.base16;
+import static org.jclouds.http.Uris.uriBuilder;
+import static org.jclouds.s3.util.StorageClassParser.parseStorageClass;
+import static org.jclouds.util.SaxUtils.currentOrNull;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import jakarta.inject.Inject;
+
+import org.jclouds.date.DateService;
+import org.jclouds.http.functions.ParseSax;
+import org.jclouds.s3.domain.CanonicalUser;
+import org.jclouds.s3.domain.ListBucketResponse;
+import org.jclouds.s3.domain.ObjectMetadata;
+import org.jclouds.s3.domain.ObjectMetadata.StorageClass;
+import org.jclouds.s3.domain.ObjectMetadataBuilder;
+import org.jclouds.s3.domain.internal.ListBucketResponseImpl;
+import org.jclouds.util.Strings2;
+import org.xml.sax.Attributes;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSet.Builder;
+
+/**
+ * Parses the following XML document:
+ * <p/>
+ * ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01"
+ */
+public class ListBucketHandler extends ParseSax.HandlerWithResult<ListBucketResponse> {
+   private Builder<ObjectMetadata> contents = ImmutableSet.builder();
+   private Builder<String> commonPrefixes = ImmutableSet.builder();
+   private CanonicalUser currentOwner;
+   private StringBuilder currentText = new StringBuilder();
+
+   private ObjectMetadataBuilder builder = new ObjectMetadataBuilder();
+
+   private final DateService dateParser;
+
+   private String bucketName;
+   private String prefix;
+   private String marker;
+   private int maxResults;
+   private String delimiter;
+   private boolean isTruncated;
+
+   /** Some blobs have a non-hex suffix when created by multi-part uploads such Amazon S3. */
+   private static final Pattern ETAG_CONTENT_MD5_PATTERN = Pattern.compile("\"([0-9a-f]+)\"");
+
+   @Inject
+   public ListBucketHandler(DateService dateParser) {
+      this.dateParser = dateParser;
+      this.currentOwner = new CanonicalUser();
+   }
+
+   public ListBucketResponse getResult() {
+      return new ListBucketResponseImpl(bucketName, contents.build(), prefix, marker,
+               (isTruncated && nextMarker == null) ? currentKey : nextMarker, maxResults, delimiter, isTruncated,
+               commonPrefixes.build());
+   }
+
+   private boolean inCommonPrefixes;
+   private String currentKey;
+   private String nextMarker;
+
+   public void startElement(String uri, String name, String qName, Attributes attrs) {
+      if (qName.equals("CommonPrefixes")) {
+         inCommonPrefixes = true;
+      }
+      currentText.setLength(0);
+   }
+
+   public void endElement(String uri, String name, String qName) {
+      if (qName.equals("ID")) {
+         currentOwner.setId(currentOrNull(currentText));
+      } else if (qName.equals("DisplayName")) {
+         currentOwner.setDisplayName(currentOrNull(currentText));
+      } else if (qName.equals("Key")) { // content stuff
+         if (currentText.length() == 0) {
+            throw new RuntimeException("Object store returned empty key name");
+         }
+         currentKey = currentText.toString();
+         builder.key(currentKey);
+         builder.uri(uriBuilder(getRequest().getEndpoint()).clearQuery().appendPath(Strings2.urlEncode(currentKey))
+               .build());
+      } else if (qName.equals("LastModified")) {
+         builder.lastModified(dateParser
+               .iso8601DateOrSecondsDateParse(currentOrNull(currentText)));
+      } else if (qName.equals("ETag")) {
+         String currentETag = currentOrNull(currentText);
+         builder.eTag(currentETag);
+         Matcher matcher = ETAG_CONTENT_MD5_PATTERN.matcher(currentETag);
+         if (matcher.matches()) {
+            builder.contentMD5(base16().lowerCase().decode(matcher.group(1)));
+         }
+      } else if (qName.equals("Size")) {
+         builder.contentLength(Long.valueOf(currentOrNull(currentText)));
+      } else if (qName.equals("Owner")) {
+         builder.owner(currentOwner);
+         currentOwner = new CanonicalUser();
+      } else if (qName.equals("StorageClass")) {
+         StorageClass storageClass = parseStorageClass(currentOrNull(currentText));
+         if (storageClass != null) {
+            builder.storageClass(storageClass);
+         }
+      } else if (qName.equals("Contents")) {
+         contents.add(builder.build());
+         builder = new ObjectMetadataBuilder().bucket(bucketName);
+      } else if (qName.equals("Name")) {
+         this.bucketName = currentOrNull(currentText);
+         builder.bucket(bucketName);
+      } else if (qName.equals("Prefix")) {
+         String prefix = currentOrNull(currentText);
+         if (inCommonPrefixes)
+            commonPrefixes.add(prefix);
+         else
+            this.prefix = prefix;
+      } else if (qName.equals("Delimiter")) {
+         this.delimiter = currentOrNull(currentText);
+      } else if (qName.equals("Marker")) {
+         this.marker = currentOrNull(currentText);
+      } else if (qName.equals("NextMarker")) {
+         this.nextMarker = currentOrNull(currentText);
+      } else if (qName.equals("MaxKeys")) {
+         this.maxResults = Integer.parseInt(currentOrNull(currentText));
+      } else if (qName.equals("IsTruncated")) {
+         this.isTruncated = Boolean.parseBoolean(currentOrNull(currentText));
+      }
+   }
+
+   public void characters(char[] ch, int start, int length) {
+      currentText.append(ch, start, length);
+   }
+}

--- a/src/test/java/org/jclouds/s3/util/StorageClassParserTest.java
+++ b/src/test/java/org/jclouds/s3/util/StorageClassParserTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.s3.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.jclouds.s3.domain.ObjectMetadata.StorageClass;
+import org.junit.Test;
+
+public class StorageClassParserTest {
+   @Test
+   public void parsesStorageClassCaseInsensitively() {
+      assertEquals(StorageClass.STANDARD, StorageClassParser.parseStorageClass("STANDARD"));
+      assertEquals(StorageClass.STANDARD, StorageClassParser.parseStorageClass("Standard"));
+      assertEquals(StorageClass.STANDARD, StorageClassParser.parseStorageClass("standard"));
+   }
+
+   @Test
+   public void normalizesDashes() {
+      assertEquals(StorageClass.GLACIER_IR, StorageClassParser.parseStorageClass("Glacier-IR"));
+   }
+
+   @Test
+   public void preservesNull() {
+      assertNull(StorageClassParser.parseStorageClass(null));
+   }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR handles mixed-case S3 `StorageClass` values returned by S3-compatible providers.

`artifact-manager-s3` bundles jclouds `s3-2.6.0`. While browsing archived artifacts, jclouds parses S3 listing metadata and object metadata using `StorageClass.valueOf(...)`, which is case-sensitive.

Some S3-compatible providers return semantically valid storage class values with different casing. Exoscale SOS, for example, returns:

```xml
<StorageClass>Standard</StorageClass>
```

This caused Jenkins artifact browsing to fail with:

```text
java.lang.IllegalArgumentException: No enum constant org.jclouds.s3.domain.ObjectMetadata.StorageClass.Standard
    at java.base/java.lang.Enum.valueOf(Enum.java:293)
    at org.jclouds.s3.domain.ObjectMetadata$StorageClass.valueOf(ObjectMetadata.java:36)
    at org.jclouds.s3.xml.ListBucketHandler.endElement(ListBucketHandler.java:118)
```

This PR adds a small compatibility parser that normalizes storage class values before converting them to the jclouds enum, e.g. `Standard` -> `STANDARD` and `Glacier-IR` -> `GLACIER_IR`.

Since jclouds is deprecated and bundled by this plugin, the affected jclouds parser classes are overridden locally in the plugin.

### Testing done

Before and after testing on live production instance.

Before:

- Jenkins was configured to use `artifact-manager-s3` with Exoscale SOS.
- Archived artifacts were uploaded successfully.
- Opening a Jenkins artifact URL failed with the Jenkins error page.
- Jenkins logs showed:

```text
java.lang.IllegalArgumentException: No enum constant org.jclouds.s3.domain.ObjectMetadata.StorageClass.Standard
    at java.base/java.lang.Enum.valueOf(Enum.java:293)
    at org.jclouds.s3.domain.ObjectMetadata$StorageClass.valueOf(ObjectMetadata.java:36)
    at org.jclouds.s3.xml.ListBucketHandler.endElement(ListBucketHandler.java:118)
```

After:

- Deployed patch
- Re-opened the previously failing `/artifact/...` URL.
- Artifact browsing and artifact download worked successfully.

Automated/local testing:

```bash
mvn -B -q -ntp -Dtest=StorageClassParserTest test
mvn -B -q -ntp -DskipTests package
```

The automated test covers mixed-case and dash-normalized storage class values:

- `STANDARD`
- `Standard`
- `standard`
- `Glacier-IR`

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
