### PR TITLE
Use commons-compress-api-plugin instead of direct dep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,9 +263,8 @@
     </dependency>
     <!-- just a workaround for PCT execution -->
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-compress</artifactId>
-      <version>1.28.0</version>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-compress-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Commons-compress has an api-plugin in jenkinsci - https://github.com/jenkinsci/commons-compress-api-plugin, using it will eliminate needing to manage dependency bump separately for this library - it will happen via the parent bumps. 

### Testing done

CI to pass

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

