### PR TITLE
Pick up `commons-compress` naturally

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,10 +242,6 @@
       <scope>test</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-compress</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>*</artifactId>
         </exclusion>
@@ -259,13 +255,6 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>minio</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <!-- just a workaround for PCT execution -->
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-compress</artifactId>
-      <version>1.28.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Closes #798. I do not recall the reason for ce10f394d56992f2038a6d37b152fbe24e6065f1 (#132) but https://github.com/jenkinsci/artifact-manager-s3-plugin/pull/619#discussion_r2087738578 did not correctly resolve it.