### PR TITLE
Fix Tika 4 bundled artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
-    <hpi.bundledArtifacts>aws-s3,guice-assistedinject,jakarta.ws.rs-api,jclouds-blobstore,jclouds-core,s3,sts,tika-core</hpi.bundledArtifacts>
+    <hpi.bundledArtifacts>aws-s3,commonmark,commonmark-ext-gfm-strikethrough,commonmark-ext-gfm-tables,guice-assistedinject,jakarta.ws.rs-api,jclouds-blobstore,jclouds-core,s3,sts,tika-core</hpi.bundledArtifacts>
     <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
   </properties>
 


### PR DESCRIPTION
Companion fix for #805.

Tika 4 adds three CommonMark libraries to the plugin’s compile/runtime dependency set. With strict bundled-artifact validation enabled, the HPI build rejects them until they are explicitly acknowledged. This adds exactly those artifacts to `hpi.bundledArtifacts`:

- `commonmark`
- `commonmark-ext-gfm-strikethrough`
- `commonmark-ext-gfm-tables`

Verification on JDK 21:

- `mvn -B -ntp clean verify`
- BUILD SUCCESS in 14m 03s
- 40 tests passed, 0 failures/errors, 1 repository-conditional skip
- HPI assembly passed with strict bundled-artifact validation
- SpotBugs reported 0 findings; Enforcer passed
- `git diff --check`

JAIPilot Remote was also attempted with the exact source snapshot, but `repo.jenkins-ci.org` reset while resolving the Jenkins plugin parent POM, before project loading. No remote pass is claimed. The disposable workspace and uploaded source were deleted.