### PR TITLE
Fix Testcontainers 2 module coordinates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,12 +252,12 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>localstack</artifactId>
+      <artifactId>testcontainers-localstack</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>minio</artifactId>
+      <artifactId>testcontainers-minio</artifactId>
       <scope>test</scope>
     </dependency>
     <!-- just a workaround for PCT execution -->


### PR DESCRIPTION
## Summary

This completes the Testcontainers 2.0.5 upgrade proposed in [#792](https://github.com/jenkinsci/artifact-manager-s3-plugin/pull/792).

Testcontainers 2 publishes the LocalStack and MinIO modules as `testcontainers-localstack` and `testcontainers-minio`. The old artifact IDs are no longer managed by the 2.0.5 BOM, so dependency resolution fails before compilation. This changes only those two test-scoped coordinates; package names and test behavior remain unchanged.

## Verification

- `mvn clean verify` on JDK 21
- 50 tests passed, with 2 skipped
- Docker-backed `LocalStackIntegrationTest`: 5 passed
- Docker-backed `MinioIntegrationTest`: 5 passed
- HPI assembly completed
- SpotBugs completed with zero findings
- Maven dependency and upper-bound enforcement passed
- `git diff --check`

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, and `jaipilot-review-diff`
- Execution profile: `gpt-5.6-sol · xhigh · fast`